### PR TITLE
feat(ontology): distinguish observed vs target/limit exploitation rates

### DIFF
--- a/docs/gcdfo.jsonld
+++ b/docs/gcdfo.jsonld
@@ -7971,6 +7971,99 @@
     ]
   },
   {
+    "@id": "https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000115": [
+      {
+        "@language": "en",
+        "@value": "Relates an observed exploitation-rate estimate to the target, threshold, or limit exploitation-rate value used to evaluate it."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#ObservedExploitationRate"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has target or limit exploitation rate"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate"
+      }
+    ],
+    "https://w3id.org/gcdfo/salmon#theme": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessmentTheme"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000115": [
+      {
+        "@language": "en",
+        "@value": "Relates a target, threshold, or limit exploitation-rate value to the observed exploitation-rate estimate it evaluates."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "is target or limit for observed exploitation rate"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#ObservedExploitationRate"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate"
+      }
+    ],
+    "https://w3id.org/gcdfo/salmon#theme": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessmentTheme"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/gcdfo/salmon#populationOf",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"

--- a/docs/gcdfo.owl
+++ b/docs/gcdfo.owl
@@ -387,6 +387,37 @@
     
 
 
+    <!-- https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">
+        <owl:inverseOf rdf:resource="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate"/>
+        <rdfs:domain rdf:resource="https://w3id.org/gcdfo/salmon#ObservedExploitationRate"/>
+        <rdfs:range rdf:resource="https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate"/>
+        <obo:IAO_0000115 xml:lang="en">Relates an observed exploitation-rate estimate to the target, threshold, or limit exploitation-rate value used to evaluate it.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">has target or limit exploitation rate</rdfs:label>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">
+        <rdfs:domain rdf:resource="https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate"/>
+        <rdfs:range rdf:resource="https://w3id.org/gcdfo/salmon#ObservedExploitationRate"/>
+        <obo:IAO_0000115 xml:lang="en">Relates a target, threshold, or limit exploitation-rate value to the observed exploitation-rate estimate it evaluates.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">is target or limit for observed exploitation rate</rdfs:label>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/gcdfo/salmon#populationOf -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/gcdfo/salmon#populationOf">

--- a/docs/gcdfo.ttl
+++ b/docs/gcdfo.ttl
@@ -272,6 +272,31 @@ gcdfo:hasPopulation rdf:type owl:ObjectProperty ;
                                 gcdfo:WildSalmonPolicyTheme .
 
 
+###  https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate
+gcdfo:hasTargetOrLimitExploitationRate rdf:type owl:ObjectProperty ;
+                                       owl:inverseOf gcdfo:isTargetOrLimitForObservedExploitationRate ;
+                                       rdfs:domain gcdfo:ObservedExploitationRate ;
+                                       rdfs:range gcdfo:TargetOrLimitExploitationRate ;
+                                       <http://purl.obolibrary.org/obo/IAO_0000115> "Relates an observed exploitation-rate estimate to the target, threshold, or limit exploitation-rate value used to evaluate it."@en ;
+                                       rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                       rdfs:label "has target or limit exploitation rate"@en ;
+                                       gcdfo:theme gcdfo:FisheriesManagementTheme ,
+                                                   gcdfo:PolicyGovernanceTheme ,
+                                                   gcdfo:StockAssessmentTheme .
+
+
+###  https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate
+gcdfo:isTargetOrLimitForObservedExploitationRate rdf:type owl:ObjectProperty ;
+                                                 rdfs:domain gcdfo:TargetOrLimitExploitationRate ;
+                                                 rdfs:range gcdfo:ObservedExploitationRate ;
+                                                 <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a target, threshold, or limit exploitation-rate value to the observed exploitation-rate estimate it evaluates."@en ;
+                                                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                                 rdfs:label "is target or limit for observed exploitation rate"@en ;
+                                                 gcdfo:theme gcdfo:FisheriesManagementTheme ,
+                                                             gcdfo:PolicyGovernanceTheme ,
+                                                             gcdfo:StockAssessmentTheme .
+
+
 ###  https://w3id.org/gcdfo/salmon#populationOf
 gcdfo:populationOf rdf:type owl:ObjectProperty ;
                    rdfs:domain gcdfo:Population ;

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -320,7 +320,15 @@ This ontology has the following classes and properties.</span>
       <a href="#hasPopulation" title="https://w3id.org/gcdfo/salmon#hasPopulation">has population</a>
    </li>
    <li>
+      <a href="#hasTargetOrLimitExploitationRate"
+         title="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">has target or limit exploitation rate</a>
+   </li>
+   <li>
       <a href="#http://www.w3.org/ns/dqv#inDimension" title="http://www.w3.org/ns/dqv#inDimension">in dimension</a>
+   </li>
+   <li>
+      <a href="#isTargetOrLimitForObservedExploitationRate"
+         title="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">is target or limit for observed exploitation rate</a>
    </li>
    <li>
       <a href="#populationOf" title="https://w3id.org/gcdfo/salmon#populationOf">population of</a>
@@ -1317,6 +1325,18 @@ This section provides details for each class and property defined by GC DFO Salm
    <dd>
     <a href="#TotalExploitationRate" title="https://w3id.org/gcdfo/salmon#TotalExploitationRate">Total exploitation rate</a> <sup class="type-c" title="class">c</sup>
    </dd>
+   <dt>
+    is in domain of
+   </dt>
+   <dd>
+    <a href="#hasTargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">has target or limit exploitation rate</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#isTargetOrLimitForObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">is target or limit for observed exploitation rate</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
   </dl>
  </div>
  <div class="entity" id="ObservedRateOrAbundance">
@@ -1896,6 +1916,18 @@ This section provides details for each class and property defined by GC DFO Salm
    <dd>
     <a href="#ExploitationRate" title="https://w3id.org/gcdfo/salmon#ExploitationRate">Exploitation rate</a> <sup class="type-c" title="class">c</sup>, <a href="#TargetOrLimitRateOrAbundance" title="https://w3id.org/gcdfo/salmon#TargetOrLimitRateOrAbundance">Target or limit rate or abundance</a> <sup class="type-c" title="class">c</sup>
    </dd>
+   <dt>
+    is in domain of
+   </dt>
+   <dd>
+    <a href="#isTargetOrLimitForObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">is target or limit for observed exploitation rate</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#hasTargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">has target or limit exploitation rate</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
   </dl>
  </div>
  <div class="entity" id="TargetOrLimitRateOrAbundance">
@@ -2126,7 +2158,9 @@ This section provides details for each class and property defined by GC DFO Salm
   <li><a href="#hasConservationUnit" title="https://w3id.org/gcdfo/salmon#hasConservationUnit">has Conservation Unit</a></li>
   <li><a href="#hasDeme" title="https://w3id.org/gcdfo/salmon#hasDeme">has deme</a></li>
   <li><a href="#hasPopulation" title="https://w3id.org/gcdfo/salmon#hasPopulation">has population</a></li>
+  <li><a href="#hasTargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">has target or limit exploitation rate</a></li>
   <li><a href="#http://www.w3.org/ns/dqv#inDimension" title="http://www.w3.org/ns/dqv#inDimension">in dimension</a></li>
+  <li><a href="#isTargetOrLimitForObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">is target or limit for observed exploitation rate</a></li>
   <li><a href="#populationOf" title="https://w3id.org/gcdfo/salmon#populationOf">population of</a></li>
  </ul>
  <div class="entity" id="conservationUnitOf">
@@ -2314,6 +2348,43 @@ This section provides details for each class and property defined by GC DFO Salm
    </dl>
   </div>
  </div>
+ <div class="entity" id="hasTargetOrLimitExploitationRate">
+  <h3>has target or limit exploitation rate<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate</p>
+  <div class="comment">
+   <span class="markdown">Relates an observed exploitation-rate estimate to the target, threshold, or limit exploitation-rate value used to evaluate it.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#ObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#ObservedExploitationRate">Observed exploitation rate</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#TargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate">Target or limit exploitation rate</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#isTargetOrLimitForObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">is target or limit for observed exploitation rate</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
+ </div>
  <div class="entity" id="http://www.w3.org/ns/dqv#inDimension">
   <h3>in dimension<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> http://www.w3.org/ns/dqv#inDimension</p>
@@ -2339,6 +2410,43 @@ This section provides details for each class and property defined by GC DFO Salm
     <a href="https://www.w3.org/TR/vocab-dqv/">https://www.w3.org/TR/vocab-dqv/</a>
    </dd>
   </dl>
+ </div>
+ <div class="entity" id="isTargetOrLimitForObservedExploitationRate">
+  <h3>is target or limit for observed exploitation rate<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate</p>
+  <div class="comment">
+   <span class="markdown">Relates a target, threshold, or limit exploitation-rate value to the observed exploitation-rate estimate it evaluates.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#TargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate">Target or limit exploitation rate</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#ObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#ObservedExploitationRate">Observed exploitation rate</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#hasTargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">has target or limit exploitation rate</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
  </div>
  <div class="entity" id="populationOf">
   <h3>population of<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
@@ -2547,6 +2655,20 @@ This section provides details for each class and property defined by GC DFO Salm
 <li>Added: domain https://w3id.org/gcdfo/salmon#ConservationUnit</li>
 <li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#populationOf&gt; &lt;https://w3id.org/gcdfo/salmon#hasPopulation&gt;)</li>
 <li>Added: Range https://w3id.org/gcdfo/salmon#Population</li>
+</ul>
+</li>
+<li><a href="#hasTargetOrLimitExploitationRate">https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate&gt; &lt;https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate&gt;)</li>
+<li>Added: domain https://w3id.org/gcdfo/salmon#ObservedExploitationRate</li>
+<li>Added: Range https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate</li>
+</ul>
+</li>
+<li><a href="#isTargetOrLimitForObservedExploitationRate">https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate&gt; &lt;https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate&gt;)</li>
+<li>Added: Range https://w3id.org/gcdfo/salmon#ObservedExploitationRate</li>
+<li>Added: domain https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate</li>
 </ul>
 </li>
 <li><a href="#populationOf">https://w3id.org/gcdfo/salmon#populationOf</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -774,7 +774,7 @@ This ontology has the following classes and properties.</span>
    <li>
       <a href="#http://purl.dataone.org/odo/ECSO_00002050" title="http://purl.dataone.org/odo/ECSO_00002050">year of measurement</a>
    </li>
-</ul></details><h4>Object Properties</h4><details class="gcdfo-collapsible gcdfo-overview-collapsible"><summary>7 items (expand)</summary><ul xmlns:widoco="https://w3id.org/widoco/vocab#"
+</ul></details><h4>Object Properties</h4><details class="gcdfo-collapsible gcdfo-overview-collapsible"><summary>9 items (expand)</summary><ul xmlns:widoco="https://w3id.org/widoco/vocab#"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     class="hlist">
    <li>
@@ -794,7 +794,15 @@ This ontology has the following classes and properties.</span>
       <a href="#hasPopulation" title="https://w3id.org/gcdfo/salmon#hasPopulation">has population</a>
    </li>
    <li>
+      <a href="#hasTargetOrLimitExploitationRate"
+         title="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">has target or limit exploitation rate</a>
+   </li>
+   <li>
       <a href="#http://www.w3.org/ns/dqv#inDimension" title="http://www.w3.org/ns/dqv#inDimension">in dimension</a>
+   </li>
+   <li>
+      <a href="#isTargetOrLimitForObservedExploitationRate"
+         title="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">is target or limit for observed exploitation rate</a>
    </li>
    <li>
       <a href="#populationOf" title="https://w3id.org/gcdfo/salmon#populationOf">population of</a>
@@ -3947,6 +3955,18 @@ This section provides details for each class and property defined by GC DFO Salm
    <dd>
     <a href="#TotalExploitationRate" title="https://w3id.org/gcdfo/salmon#TotalExploitationRate">Total exploitation rate</a> <sup class="type-c" title="class">c</sup>
    </dd>
+   <dt>
+    is in domain of
+   </dt>
+   <dd>
+    <a href="#hasTargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">has target or limit exploitation rate</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#isTargetOrLimitForObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">is target or limit for observed exploitation rate</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
   </dl>
  </div>
  <div class="entity" id="ObservedRateOrAbundance">
@@ -4526,6 +4546,18 @@ This section provides details for each class and property defined by GC DFO Salm
    <dd>
     <a href="#ExploitationRate" title="https://w3id.org/gcdfo/salmon#ExploitationRate">Exploitation rate</a> <sup class="type-c" title="class">c</sup>, <a href="#TargetOrLimitRateOrAbundance" title="https://w3id.org/gcdfo/salmon#TargetOrLimitRateOrAbundance">Target or limit rate or abundance</a> <sup class="type-c" title="class">c</sup>
    </dd>
+   <dt>
+    is in domain of
+   </dt>
+   <dd>
+    <a href="#isTargetOrLimitForObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">is target or limit for observed exploitation rate</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#hasTargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">has target or limit exploitation rate</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
   </dl>
  </div>
  <div class="entity" id="TargetOrLimitRateOrAbundance">
@@ -4756,7 +4788,9 @@ This section provides details for each class and property defined by GC DFO Salm
   <li><a href="#hasConservationUnit" title="https://w3id.org/gcdfo/salmon#hasConservationUnit">has Conservation Unit</a></li>
   <li><a href="#hasDeme" title="https://w3id.org/gcdfo/salmon#hasDeme">has deme</a></li>
   <li><a href="#hasPopulation" title="https://w3id.org/gcdfo/salmon#hasPopulation">has population</a></li>
+  <li><a href="#hasTargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">has target or limit exploitation rate</a></li>
   <li><a href="#http://www.w3.org/ns/dqv#inDimension" title="http://www.w3.org/ns/dqv#inDimension">in dimension</a></li>
+  <li><a href="#isTargetOrLimitForObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">is target or limit for observed exploitation rate</a></li>
   <li><a href="#populationOf" title="https://w3id.org/gcdfo/salmon#populationOf">population of</a></li>
  </ul>
  <div class="entity" id="conservationUnitOf">
@@ -4944,6 +4978,43 @@ This section provides details for each class and property defined by GC DFO Salm
    </dl>
   </div>
  </div>
+ <div class="entity" id="hasTargetOrLimitExploitationRate">
+  <h3>has target or limit exploitation rate<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate</p>
+  <div class="comment">
+   <span class="markdown">Relates an observed exploitation-rate estimate to the target, threshold, or limit exploitation-rate value used to evaluate it.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#ObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#ObservedExploitationRate">Observed exploitation rate</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#TargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate">Target or limit exploitation rate</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#isTargetOrLimitForObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">is target or limit for observed exploitation rate</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
+ </div>
  <div class="entity" id="http://www.w3.org/ns/dqv#inDimension">
   <h3>in dimension<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> http://www.w3.org/ns/dqv#inDimension</p>
@@ -4969,6 +5040,43 @@ This section provides details for each class and property defined by GC DFO Salm
     <a href="https://www.w3.org/TR/vocab-dqv/">https://www.w3.org/TR/vocab-dqv/</a>
    </dd>
   </dl>
+ </div>
+ <div class="entity" id="isTargetOrLimitForObservedExploitationRate">
+  <h3>is target or limit for observed exploitation rate<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate</p>
+  <div class="comment">
+   <span class="markdown">Relates a target, threshold, or limit exploitation-rate value to the observed exploitation-rate estimate it evaluates.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#TargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate">Target or limit exploitation rate</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#ObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#ObservedExploitationRate">Observed exploitation rate</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#hasTargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">has target or limit exploitation rate</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
  </div>
  <div class="entity" id="populationOf">
   <h3>population of<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
@@ -5177,6 +5285,20 @@ This section provides details for each class and property defined by GC DFO Salm
 <li>Added: domain https://w3id.org/gcdfo/salmon#ConservationUnit</li>
 <li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#populationOf&gt; &lt;https://w3id.org/gcdfo/salmon#hasPopulation&gt;)</li>
 <li>Added: Range https://w3id.org/gcdfo/salmon#Population</li>
+</ul>
+</li>
+<li><a href="#hasTargetOrLimitExploitationRate">https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate&gt; &lt;https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate&gt;)</li>
+<li>Added: domain https://w3id.org/gcdfo/salmon#ObservedExploitationRate</li>
+<li>Added: Range https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate</li>
+</ul>
+</li>
+<li><a href="#isTargetOrLimitForObservedExploitationRate">https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate&gt; &lt;https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate&gt;)</li>
+<li>Added: Range https://w3id.org/gcdfo/salmon#ObservedExploitationRate</li>
+<li>Added: domain https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate</li>
 </ul>
 </li>
 <li><a href="#populationOf">https://w3id.org/gcdfo/salmon#populationOf</a>

--- a/draft/dfo-salmon-draft.ttl
+++ b/draft/dfo-salmon-draft.ttl
@@ -940,6 +940,21 @@ gcdfo:hasYearBasis a owl:ObjectProperty ;
   rdfs:range [ owl:unionOf ( gcdfo:BroodYear gcdfo:CatchYear ) ] ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
 
+gcdfo:hasTargetOrLimitExploitationRate a owl:ObjectProperty ;
+  rdfs:label "has target or limit exploitation rate"@en ;
+  iao:0000115 "Relates an observed exploitation-rate estimate to the target, threshold, or limit exploitation-rate value used to evaluate it."@en ; # definition
+  rdfs:domain gcdfo:ObservedExploitationRate ;
+  rdfs:range gcdfo:TargetOrLimitExploitationRate ;
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+
+gcdfo:isTargetOrLimitForObservedExploitationRate a owl:ObjectProperty ;
+  rdfs:label "is target or limit for observed exploitation rate"@en ;
+  iao:0000115 "Relates a target, threshold, or limit exploitation-rate value to the observed exploitation-rate estimate it evaluates."@en ; # definition
+  owl:inverseOf gcdfo:hasTargetOrLimitExploitationRate ;
+  rdfs:domain gcdfo:TargetOrLimitExploitationRate ;
+  rdfs:range gcdfo:ObservedExploitationRate ;
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+
 gcdfo:Catch a owl:Class ;
   rdfs:label "Catch"@en ;
   iao:0000115 "The number of adult fishes that are caught in commercial, recreational, and First Nations fisheries."@en ; # definition

--- a/ontology/dfo-salmon.ttl
+++ b/ontology/dfo-salmon.ttl
@@ -1414,6 +1414,23 @@ gcdfo:conservationUnitOf a owl:ObjectProperty ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
   gcdfo:theme gcdfo:FisheriesManagementTheme, gcdfo:WildSalmonPolicyTheme, gcdfo:PolicyGovernanceTheme .
 
+gcdfo:hasTargetOrLimitExploitationRate a owl:ObjectProperty ;
+  rdfs:label "has target or limit exploitation rate"@en ;
+  iao:0000115 "Relates an observed exploitation-rate estimate to the target, threshold, or limit exploitation-rate value used to evaluate it."@en ; # definition
+  rdfs:domain gcdfo:ObservedExploitationRate ;
+  rdfs:range gcdfo:TargetOrLimitExploitationRate ;
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:FisheriesManagementTheme, gcdfo:PolicyGovernanceTheme .
+
+gcdfo:isTargetOrLimitForObservedExploitationRate a owl:ObjectProperty ;
+  rdfs:label "is target or limit for observed exploitation rate"@en ;
+  iao:0000115 "Relates a target, threshold, or limit exploitation-rate value to the observed exploitation-rate estimate it evaluates."@en ; # definition
+  owl:inverseOf gcdfo:hasTargetOrLimitExploitationRate ;
+  rdfs:domain gcdfo:TargetOrLimitExploitationRate ;
+  rdfs:range gcdfo:ObservedExploitationRate ;
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:FisheriesManagementTheme, gcdfo:PolicyGovernanceTheme .
+
 #################################################################
 # OWL Classes
 #################################################################


### PR DESCRIPTION
## Summary
This PR separates exploitation-rate semantics into observed versus policy-target/limit forms while keeping a shared parent concept.

## Changes
- Updated `gcdfo:ExploitationRate` to a neutral parent concept (`subClassOf iao:0000109`).
- Added `gcdfo:ObservedExploitationRate` as a subclass of:
  - `gcdfo:ExploitationRate`
  - `gcdfo:ObservedRateOrAbundance`
- Added `gcdfo:TargetOrLimitExploitationRate` as a subclass of:
  - `gcdfo:ExploitationRate`
  - `gcdfo:TargetOrLimitRateOrAbundance`
- Repointed `gcdfo:TotalExploitationRate` to subclass `gcdfo:ObservedExploitationRate`.
- Mirrored the same model updates in `draft/dfo-salmon-draft.ttl`.
- Regenerated docs artifacts (`docs/gcdfo.ttl`, `docs/gcdfo.owl`, `docs/gcdfo.jsonld`, `docs/index.html`, `docs/index-en.html`).

## Why
DFO usage supports both:
- realized/estimated exploitation rates (observed), and
- management reference values (targets/thresholds/limits).

This change avoids conflating those two semantics in one class while preserving a simple hierarchy.

## Validation
- `make ci` passed locally.
