### PR TITLE
fix: model IndicatorRiver as reporting/management stratum

### DIFF
--- a/docs/gcdfo.jsonld
+++ b/docs/gcdfo.jsonld
@@ -4112,7 +4112,7 @@
     "http://purl.obolibrary.org/obo/IAO_0000115": [
       {
         "@language": "en",
-        "@value": "Indicator streams are those that have been identified in some Regions as providing more reliable indices of spawner abundance. Indicator streams tend to give relatively accurate annual spawner abundance estimates, given that they use higher quality methodologies and are more intensively/regularly surveyed. Indicator streams are also assumed to be representative of spawner returns to other streams in close geographic proximity."
+        "@value": "A reporting and assessment stratum identifying monitored indicator streams that provide representative indices of spawner abundance for nearby streams."
       }
     ],
     "http://purl.org/dc/terms/source": [
@@ -4131,6 +4131,11 @@
         "@value": "Indicator river"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
       {
         "@language": "en",
@@ -4140,6 +4145,9 @@
     "https://w3id.org/gcdfo/salmon#theme": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#MonitoringFieldWorkTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"
       },
       {
         "@id": "https://w3id.org/gcdfo/salmon#StockAssessmentTheme"

--- a/docs/gcdfo.owl
+++ b/docs/gcdfo.owl
@@ -876,12 +876,14 @@
     <!-- https://w3id.org/gcdfo/salmon#IndicatorRiver -->
 
     <owl:Class rdf:about="https://w3id.org/gcdfo/salmon#IndicatorRiver">
-        <obo:IAO_0000115 xml:lang="en">Indicator streams are those that have been identified in some Regions as providing more reliable indices of spawner abundance. Indicator streams tend to give relatively accurate annual spawner abundance estimates, given that they use higher quality methodologies and are more intensively/regularly surveyed. Indicator streams are also assumed to be representative of spawner returns to other streams in close geographic proximity.</obo:IAO_0000115>
+        <rdfs:subClassOf rdf:resource="https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum"/>
+        <obo:IAO_0000115 xml:lang="en">A reporting and assessment stratum identifying monitored indicator streams that provide representative indices of spawner abundance for nearby streams.</obo:IAO_0000115>
         <dcterms:source rdf:resource="https://www.salmonexplorer.ca/methods/glossary.html"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
         <rdfs:label xml:lang="en">Indicator river</rdfs:label>
         <skos:altLabel xml:lang="en">Indicator stream</skos:altLabel>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#MonitoringFieldWorkTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
     </owl:Class>
     

--- a/docs/gcdfo.ttl
+++ b/docs/gcdfo.ttl
@@ -633,12 +633,14 @@ gcdfo:ExploitationRate rdf:type owl:Class ;
 
 ###  https://w3id.org/gcdfo/salmon#IndicatorRiver
 gcdfo:IndicatorRiver rdf:type owl:Class ;
-                     <http://purl.obolibrary.org/obo/IAO_0000115> "Indicator streams are those that have been identified in some Regions as providing more reliable indices of spawner abundance. Indicator streams tend to give relatively accurate annual spawner abundance estimates, given that they use higher quality methodologies and are more intensively/regularly surveyed. Indicator streams are also assumed to be representative of spawner returns to other streams in close geographic proximity."@en ;
+                     rdfs:subClassOf gcdfo:ReportingOrManagementStratum ;
+                     <http://purl.obolibrary.org/obo/IAO_0000115> "A reporting and assessment stratum identifying monitored indicator streams that provide representative indices of spawner abundance for nearby streams."@en ;
                      dcterms:source <https://www.salmonexplorer.ca/methods/glossary.html> ;
                      rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
                      rdfs:label "Indicator river"@en ;
                      skos:altLabel "Indicator stream"@en ;
                      gcdfo:theme gcdfo:MonitoringFieldWorkTheme ,
+                                 gcdfo:PolicyGovernanceTheme ,
                                  gcdfo:StockAssessmentTheme .
 
 

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -949,7 +949,7 @@ This section provides details for each class and property defined by GC DFO Salm
   <h3>Indicator river<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#IndicatorRiver</p>
   <div class="comment">
-   <span class="markdown">Indicator streams are those that have been identified in some Regions as providing more reliable indices of spawner abundance. Indicator streams tend to give relatively accurate annual spawner abundance estimates, given that they use higher quality methodologies and are more intensively/regularly surveyed. Indicator streams are also assumed to be representative of spawner returns to other streams in close geographic proximity.</span>
+   <span class="markdown">A reporting and assessment stratum identifying monitored indicator streams that provide representative indices of spawner abundance for nearby streams.</span>
   </div>
   <dl class="definedBy">
    <dt>
@@ -965,6 +965,14 @@ This section provides details for each class and property defined by GC DFO Salm
    </dt>
    <dd>
     <a href="https://www.salmonexplorer.ca/methods/glossary.html">https://www.salmonexplorer.ca/methods/glossary.html</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    has super-classes
+   </dt>
+   <dd>
+    <a href="#ReportingOrManagementStratum" title="https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum">Reporting or management stratum</a> <sup class="type-c" title="class">c</sup>
    </dd>
   </dl>
  </div>
@@ -1557,7 +1565,7 @@ This section provides details for each class and property defined by GC DFO Salm
     has sub-classes
    </dt>
    <dd>
-    <a href="#ConservationUnit" title="https://w3id.org/gcdfo/salmon#ConservationUnit">Conservation Unit</a> <sup class="type-c" title="class">c</sup>, <a href="#Stock" title="https://w3id.org/gcdfo/salmon#Stock">Stock</a> <sup class="type-c" title="class">c</sup>, <a href="#StockManagementUnit" title="https://w3id.org/gcdfo/salmon#StockManagementUnit">Stock Management Unit</a> <sup class="type-c" title="class">c</sup>
+    <a href="#ConservationUnit" title="https://w3id.org/gcdfo/salmon#ConservationUnit">Conservation Unit</a> <sup class="type-c" title="class">c</sup>, <a href="#IndicatorRiver" title="https://w3id.org/gcdfo/salmon#IndicatorRiver">Indicator river</a> <sup class="type-c" title="class">c</sup>, <a href="#Stock" title="https://w3id.org/gcdfo/salmon#Stock">Stock</a> <sup class="type-c" title="class">c</sup>, <a href="#StockManagementUnit" title="https://w3id.org/gcdfo/salmon#StockManagementUnit">Stock Management Unit</a> <sup class="type-c" title="class">c</sup>
    </dd>
   </dl>
  </div>
@@ -2312,6 +2320,16 @@ This section provides details for each class and property defined by GC DFO Salm
 <li><a href="#EscapementMeasurement">https://w3id.org/gcdfo/salmon#EscapementMeasurement</a>
 <ul>
 <li>Deleted: rdfs:comment "Salmon escapement count"@en</li>
+</ul>
+</li>
+<li><a href="#IndicatorRiver">https://w3id.org/gcdfo/salmon#IndicatorRiver</a>
+<ul>
+<li>Added: <http://purl.obolibrary.org/obo/IAO_0000115> "A reporting and assessment stratum identifying monitored indicator streams that provide representative indices of spawner abundance for nearby streams."@en</li>
+<li>Added: <https://w3id.org/gcdfo/salmon#theme> https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme</li>
+<li>Added: SubClass of https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum</li>
+</ul>
+<ul>
+<li>Deleted: <http://purl.obolibrary.org/obo/IAO_0000115> "Indicator streams are those that have been identified in some Regions as providing more reliable indices of spawner abundance. Indicator streams tend to give relatively accurate annual spawner abundance estimates, given that they use higher quality methodologies and are more intensively/regularly surveyed. Indicator streams are also assumed to be representative of spawner returns to other streams in close geographic proximity."@en</li>
 </ul>
 </li>
 <li><a href="#MetricBenchmark">https://w3id.org/gcdfo/salmon#MetricBenchmark</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3579,7 +3579,7 @@ This section provides details for each class and property defined by GC DFO Salm
   <h3>Indicator river<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#IndicatorRiver</p>
   <div class="comment">
-   <span class="markdown">Indicator streams are those that have been identified in some Regions as providing more reliable indices of spawner abundance. Indicator streams tend to give relatively accurate annual spawner abundance estimates, given that they use higher quality methodologies and are more intensively/regularly surveyed. Indicator streams are also assumed to be representative of spawner returns to other streams in close geographic proximity.</span>
+   <span class="markdown">A reporting and assessment stratum identifying monitored indicator streams that provide representative indices of spawner abundance for nearby streams.</span>
   </div>
   <dl class="definedBy">
    <dt>
@@ -3595,6 +3595,14 @@ This section provides details for each class and property defined by GC DFO Salm
    </dt>
    <dd>
     <a href="https://www.salmonexplorer.ca/methods/glossary.html">https://www.salmonexplorer.ca/methods/glossary.html</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    has super-classes
+   </dt>
+   <dd>
+    <a href="#ReportingOrManagementStratum" title="https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum">Reporting or management stratum</a> <sup class="type-c" title="class">c</sup>
    </dd>
   </dl>
  </div>
@@ -4187,7 +4195,7 @@ This section provides details for each class and property defined by GC DFO Salm
     has sub-classes
    </dt>
    <dd>
-    <a href="#ConservationUnit" title="https://w3id.org/gcdfo/salmon#ConservationUnit">Conservation Unit</a> <sup class="type-c" title="class">c</sup>, <a href="#Stock" title="https://w3id.org/gcdfo/salmon#Stock">Stock</a> <sup class="type-c" title="class">c</sup>, <a href="#StockManagementUnit" title="https://w3id.org/gcdfo/salmon#StockManagementUnit">Stock Management Unit</a> <sup class="type-c" title="class">c</sup>
+    <a href="#ConservationUnit" title="https://w3id.org/gcdfo/salmon#ConservationUnit">Conservation Unit</a> <sup class="type-c" title="class">c</sup>, <a href="#IndicatorRiver" title="https://w3id.org/gcdfo/salmon#IndicatorRiver">Indicator river</a> <sup class="type-c" title="class">c</sup>, <a href="#Stock" title="https://w3id.org/gcdfo/salmon#Stock">Stock</a> <sup class="type-c" title="class">c</sup>, <a href="#StockManagementUnit" title="https://w3id.org/gcdfo/salmon#StockManagementUnit">Stock Management Unit</a> <sup class="type-c" title="class">c</sup>
    </dd>
   </dl>
  </div>
@@ -4942,6 +4950,16 @@ This section provides details for each class and property defined by GC DFO Salm
 <li><a href="#EscapementMeasurement">https://w3id.org/gcdfo/salmon#EscapementMeasurement</a>
 <ul>
 <li>Deleted: rdfs:comment "Salmon escapement count"@en</li>
+</ul>
+</li>
+<li><a href="#IndicatorRiver">https://w3id.org/gcdfo/salmon#IndicatorRiver</a>
+<ul>
+<li>Added: <http://purl.obolibrary.org/obo/IAO_0000115> "A reporting and assessment stratum identifying monitored indicator streams that provide representative indices of spawner abundance for nearby streams."@en</li>
+<li>Added: <https://w3id.org/gcdfo/salmon#theme> https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme</li>
+<li>Added: SubClass of https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum</li>
+</ul>
+<ul>
+<li>Deleted: <http://purl.obolibrary.org/obo/IAO_0000115> "Indicator streams are those that have been identified in some Regions as providing more reliable indices of spawner abundance. Indicator streams tend to give relatively accurate annual spawner abundance estimates, given that they use higher quality methodologies and are more intensively/regularly surveyed. Indicator streams are also assumed to be representative of spawner returns to other streams in close geographic proximity."@en</li>
 </ul>
 </li>
 <li><a href="#MetricBenchmark">https://w3id.org/gcdfo/salmon#MetricBenchmark</a>

--- a/draft/dfo-salmon-draft.ttl
+++ b/draft/dfo-salmon-draft.ttl
@@ -1228,8 +1228,8 @@ gcdfo:IndicatorPopulation a owl:Class ;
 gcdfo:IndicatorRiver a owl:Class ;
   rdfs:label "Indicator river"@en ;
   skos:altLabel "Indicator stream"@en ;
-  rdfs:subClassOf envo:01000618 ; # lotic water body
-  iao:0000115 "All spawning streams that are listed to be monitored by DFO are classified as an indicator or non-indicator stream. Indicator streams are those that have been identified in some Regions as providing more reliable indices of spawner abundance. Indicator streams tend to give relatively accurate annual spawner abundance estimates, given that they use higher quality methodologies and are more intensively/regularly surveyed. Indicator streams are also assumed to be representative of spawner returns to other streams in close geographic proximity. Non-indicator streams are typically less consistently surveyed, using more variable methodologies, and/or may simply be difficult to survey (e.g., poor water quality, remote location, etc.)."@en ; # definition
+  rdfs:subClassOf gcdfo:ReportingOrManagementStratum ;
+  iao:0000115 "A reporting and assessment stratum identifying monitored indicator streams that provide representative indices of spawner abundance for nearby streams."@en ; # definition
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
 
 gcdfo:GraphicalVisualization a owl:Class ;
@@ -3190,7 +3190,7 @@ gcdfo:HealthyZone gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:FisheriesManage
 gcdfo:IndexBased gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:FisheriesManagementTheme .
 gcdfo:Indicator gcdfo:theme gcdfo:StockAssessmentTheme .
 gcdfo:IndicatorPopulation gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:FisheriesManagementTheme , gcdfo:SalmonEnhancementHatcheriesTheme .
-gcdfo:IndicatorRiver gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:MonitoringFieldWorkTheme , gcdfo:HabitatEcosystemClimateTheme .
+gcdfo:IndicatorRiver gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:MonitoringFieldWorkTheme , gcdfo:PolicyGovernanceTheme .
 gcdfo:KobePlot gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:FisheriesManagementTheme .
 gcdfo:LifeCycleModel gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:SalmonEnhancementHatcheriesTheme , gcdfo:PolicyGovernanceTheme .
 gcdfo:LimitReferencePoint gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:FisheriesManagementTheme , gcdfo:SpeciesAtRiskRecoveryTheme .

--- a/ontology/dfo-salmon.ttl
+++ b/ontology/dfo-salmon.ttl
@@ -1679,7 +1679,8 @@ gcdfo:TotalExploitationRate a owl:Class ;
 gcdfo:IndicatorRiver a owl:Class ;
   rdfs:label "Indicator river"@en ;
   skos:altLabel "Indicator stream"@en ;
-  iao:0000115 "Indicator streams are those that have been identified in some Regions as providing more reliable indices of spawner abundance. Indicator streams tend to give relatively accurate annual spawner abundance estimates, given that they use higher quality methodologies and are more intensively/regularly surveyed. Indicator streams are also assumed to be representative of spawner returns to other streams in close geographic proximity."@en ; # definition
-  gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:MonitoringFieldWorkTheme ;
+  rdfs:subClassOf gcdfo:ReportingOrManagementStratum ;
+  iao:0000115 "A reporting and assessment stratum identifying monitored indicator streams that provide representative indices of spawner abundance for nearby streams."@en ; # definition
+  gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:MonitoringFieldWorkTheme, gcdfo:PolicyGovernanceTheme ;
   dcterms:source <https://www.salmonexplorer.ca/methods/glossary.html> ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .


### PR DESCRIPTION
## Summary
Closes #42.

This PR applies Brett's modeling direction for `gcdfo:IndicatorRiver` in both source ontology files.

### What changed
- `ontology/dfo-salmon.ttl`
  - Added `rdfs:subClassOf gcdfo:ReportingOrManagementStratum` for `gcdfo:IndicatorRiver`.
  - Updated definition to emphasize representative reporting/index-stratum semantics.
  - Added `gcdfo:PolicyGovernanceTheme` to align with reporting/management stratum framing.
- `draft/dfo-salmon-draft.ttl`
  - Replaced `rdfs:subClassOf envo:01000618` with `rdfs:subClassOf gcdfo:ReportingOrManagementStratum`.
  - Updated definition with the same reporting/index-stratum semantics.
  - Updated draft theme mapping from `gcdfo:HabitatEcosystemClimateTheme` to `gcdfo:PolicyGovernanceTheme`.
- Refreshed generated documentation artifacts via CI/docs pipeline:
  - `docs/gcdfo.ttl`, `docs/gcdfo.owl`, `docs/gcdfo.jsonld`, `docs/index.html`, `docs/index-en.html`

### Validation
- Ran full CI/docs refresh:
  - `make ci` (with `openjdk@11` environment)
