### PR TITLE
Add FRP-L term for SMU lower fisheries reference points

### DIFF
--- a/docs/gcdfo.jsonld
+++ b/docs/gcdfo.jsonld
@@ -3577,6 +3577,57 @@
     ]
   },
   {
+    "@id": "https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000115": [
+      {
+        "@language": "en",
+        "@value": "A lower fisheries-management reference point defined for Stock Management Units (SMUs) and related fishery decision frameworks. It may be informed by Conservation Unit (CU) lower biological benchmarks, but is not identical to CU-level lower biological benchmarks used to delineate Wild Salmon Policy biological status zones."
+      }
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000119": [
+      {
+        "@language": "en",
+        "@value": "Fisheries and Oceans Canada. (2022). Methodologies and Guidelines for Defining Limit Reference Points for Pacific Salmon. DFO Can. Sci. Advis. Sec. Sci. Advis. Rep. 2022/030. (Erratum: December 2022)."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Fisheries Reference Point - Lower"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#LimitReferencePoint"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#altLabel": [
+      {
+        "@language": "en",
+        "@value": "FRP-L"
+      }
+    ],
+    "https://w3id.org/gcdfo/salmon#theme": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessmentTheme"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/gcdfo/salmon#FixedSiteCensusElectronic",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -4354,7 +4405,7 @@
     "http://purl.obolibrary.org/obo/IAO_0000115": [
       {
         "@language": "en",
-        "@value": "Lower benchmark value for a metric used to delineate Wild Salmon Policy status zones (typically the boundary between Red and Amber zones)."
+        "@value": "Lower benchmark value for a Conservation Unit (CU) metric used to delineate Wild Salmon Policy status zones (typically the boundary between Red and Amber zones). This CU-level biological benchmark is distinct from SMU-level fisheries management lower reference points such as FRP-L."
       }
     ],
     "http://purl.obolibrary.org/obo/IAO_0000119": [

--- a/docs/gcdfo.owl
+++ b/docs/gcdfo.owl
@@ -873,6 +873,22 @@
     
 
 
+    <!-- https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower -->
+
+    <owl:Class rdf:about="https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/gcdfo/salmon#LimitReferencePoint"/>
+        <obo:IAO_0000115 xml:lang="en">A lower fisheries-management reference point defined for Stock Management Units (SMUs) and related fishery decision frameworks. It may be informed by Conservation Unit (CU) lower biological benchmarks, but is not identical to CU-level lower biological benchmarks used to delineate Wild Salmon Policy biological status zones.</obo:IAO_0000115>
+        <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. (2022). Methodologies and Guidelines for Defining Limit Reference Points for Pacific Salmon. DFO Can. Sci. Advis. Sec. Sci. Advis. Rep. 2022/030. (Erratum: December 2022).</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Fisheries Reference Point - Lower</rdfs:label>
+        <skos:altLabel xml:lang="en">FRP-L</skos:altLabel>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/gcdfo/salmon#IndicatorRiver -->
 
     <owl:Class rdf:about="https://w3id.org/gcdfo/salmon#IndicatorRiver">
@@ -907,7 +923,7 @@
 
     <owl:Class rdf:about="https://w3id.org/gcdfo/salmon#LowerBiologicalBenchmark">
         <rdfs:subClassOf rdf:resource="https://w3id.org/gcdfo/salmon#MetricBenchmark"/>
-        <obo:IAO_0000115 xml:lang="en">Lower benchmark value for a metric used to delineate Wild Salmon Policy status zones (typically the boundary between Red and Amber zones).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Lower benchmark value for a Conservation Unit (CU) metric used to delineate Wild Salmon Policy status zones (typically the boundary between Red and Amber zones). This CU-level biological benchmark is distinct from SMU-level fisheries management lower reference points such as FRP-L.</obo:IAO_0000115>
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. (2021). Wild Salmon Policy 2018-2022 Implementation Plan. Available at https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>

--- a/docs/gcdfo.ttl
+++ b/docs/gcdfo.ttl
@@ -631,6 +631,19 @@ gcdfo:ExploitationRate rdf:type owl:Class ;
                                    gcdfo:StockAssessmentTheme .
 
 
+###  https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower
+gcdfo:FisheriesReferencePointLower rdf:type owl:Class ;
+                                   rdfs:subClassOf gcdfo:LimitReferencePoint ;
+                                   <http://purl.obolibrary.org/obo/IAO_0000115> "A lower fisheries-management reference point defined for Stock Management Units (SMUs) and related fishery decision frameworks. It may be informed by Conservation Unit (CU) lower biological benchmarks, but is not identical to CU-level lower biological benchmarks used to delineate Wild Salmon Policy biological status zones."@en ;
+                                   <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. (2022). Methodologies and Guidelines for Defining Limit Reference Points for Pacific Salmon. DFO Can. Sci. Advis. Sec. Sci. Advis. Rep. 2022/030. (Erratum: December 2022)."@en ;
+                                   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                   rdfs:label "Fisheries Reference Point - Lower"@en ;
+                                   skos:altLabel "FRP-L"@en ;
+                                   gcdfo:theme gcdfo:FisheriesManagementTheme ,
+                                               gcdfo:PolicyGovernanceTheme ,
+                                               gcdfo:StockAssessmentTheme .
+
+
 ###  https://w3id.org/gcdfo/salmon#IndicatorRiver
 gcdfo:IndicatorRiver rdf:type owl:Class ;
                      <http://purl.obolibrary.org/obo/IAO_0000115> "Indicator streams are those that have been identified in some Regions as providing more reliable indices of spawner abundance. Indicator streams tend to give relatively accurate annual spawner abundance estimates, given that they use higher quality methodologies and are more intensively/regularly surveyed. Indicator streams are also assumed to be representative of spawner returns to other streams in close geographic proximity."@en ;
@@ -658,7 +671,7 @@ gcdfo:LimitReferencePoint rdf:type owl:Class ;
 ###  https://w3id.org/gcdfo/salmon#LowerBiologicalBenchmark
 gcdfo:LowerBiologicalBenchmark rdf:type owl:Class ;
                                rdfs:subClassOf gcdfo:MetricBenchmark ;
-                               <http://purl.obolibrary.org/obo/IAO_0000115> "Lower benchmark value for a metric used to delineate Wild Salmon Policy status zones (typically the boundary between Red and Amber zones)."@en ;
+                               <http://purl.obolibrary.org/obo/IAO_0000115> "Lower benchmark value for a Conservation Unit (CU) metric used to delineate Wild Salmon Policy status zones (typically the boundary between Red and Amber zones). This CU-level biological benchmark is distinct from SMU-level fisheries management lower reference points such as FRP-L."@en ;
                                <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. (2021). Wild Salmon Policy 2018-2022 Implementation Plan. Available at https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf."@en ;
                                dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf> ;
                                rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -163,6 +163,10 @@ This ontology has the following classes and properties.</span>
       <a href="#http://purl.dataone.org/odo/SALMON_00000639" title="http://purl.dataone.org/odo/SALMON_00000639">Fish stock type</a>
    </li>
    <li>
+      <a href="#FisheriesReferencePointLower"
+         title="https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower">Fisheries Reference Point - Lower</a>
+   </li>
+   <li>
       <a href="#http://purl.dataone.org/odo/SALMON_00000137" title="http://purl.dataone.org/odo/SALMON_00000137">Fishery type</a>
    </li>
    <li>
@@ -349,6 +353,7 @@ This section provides details for each class and property defined by GC DFO Salm
   <li><a href="#ExploitationRate" title="https://w3id.org/gcdfo/salmon#ExploitationRate">Exploitation rate</a></li>
   <li><a href="#http://purl.dataone.org/odo/SALMON_00000167" title="http://purl.dataone.org/odo/SALMON_00000167">Fish measurement type</a></li>
   <li><a href="#http://purl.dataone.org/odo/SALMON_00000639" title="http://purl.dataone.org/odo/SALMON_00000639">Fish stock type</a></li>
+  <li><a href="#FisheriesReferencePointLower" title="https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower">Fisheries Reference Point - Lower</a></li>
   <li><a href="#http://purl.dataone.org/odo/SALMON_00000137" title="http://purl.dataone.org/odo/SALMON_00000137">Fishery type</a></li>
   <li><a href="#http://purl.obolibrary.org/obo/BFO_0000031" title="http://purl.obolibrary.org/obo/BFO_0000031">generically dependent continuant</a></li>
   <li><a href="#http://rs.tdwg.org/dwc/terms/Identification" title="http://rs.tdwg.org/dwc/terms/Identification">Identification</a></li>
@@ -868,6 +873,37 @@ This section provides details for each class and property defined by GC DFO Salm
    </dd>
   </dl>
  </div>
+ <div class="entity" id="FisheriesReferencePointLower">
+  <h3>Fisheries Reference Point - Lower<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower</p>
+  <div class="comment">
+   <span class="markdown">A lower fisheries-management reference point defined for Stock Management Units (SMUs) and related fishery decision frameworks. It may be informed by Conservation Unit (CU) lower biological benchmarks, but is not identical to CU-level lower biological benchmarks used to delineate Wild Salmon Policy biological status zones.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <dl class="definedBy">
+   <dt>
+    Source
+   </dt>
+   <dd>
+    Fisheries and Oceans Canada. (2022). Methodologies and Guidelines for Defining Limit Reference Points for Pacific Salmon. DFO Can. Sci. Advis. Sec. Sci. Advis. Rep. 2022/030. (Erratum: December 2022).
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    has super-classes
+   </dt>
+   <dd>
+    <a href="#LimitReferencePoint" title="https://w3id.org/gcdfo/salmon#LimitReferencePoint">Limit reference point</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+  </dl>
+ </div>
  <div class="entity" id="http://purl.dataone.org/odo/SALMON_00000137">
   <h3>Fishery type<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> http://purl.dataone.org/odo/SALMON_00000137</p>
@@ -1078,6 +1114,12 @@ This section provides details for each class and property defined by GC DFO Salm
    <dd>
     <a href="#ReferencePoint" title="https://w3id.org/gcdfo/salmon#ReferencePoint">Reference point</a> <sup class="type-c" title="class">c</sup>
    </dd>
+   <dt>
+    has sub-classes
+   </dt>
+   <dd>
+    <a href="#FisheriesReferencePointLower" title="https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower">Fisheries Reference Point - Lower</a> <sup class="type-c" title="class">c</sup>
+   </dd>
   </dl>
  </div>
  <div class="entity" id="http://purl.obolibrary.org/obo/ENVO_01000618">
@@ -1113,7 +1155,7 @@ This section provides details for each class and property defined by GC DFO Salm
   <h3>Lower biological benchmark<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#LowerBiologicalBenchmark</p>
   <div class="comment">
-   <span class="markdown">Lower benchmark value for a metric used to delineate Wild Salmon Policy status zones (typically the boundary between Red and Amber zones).</span>
+   <span class="markdown">Lower benchmark value for a Conservation Unit (CU) metric used to delineate Wild Salmon Policy status zones (typically the boundary between Red and Amber zones). This CU-level biological benchmark is distinct from SMU-level fisheries management lower reference points such as FRP-L.</span>
   </div>
   <dl class="definedBy">
    <dt>
@@ -2361,6 +2403,11 @@ This section provides details for each class and property defined by GC DFO Salm
 <ul><li><a href="#Deme">https://w3id.org/gcdfo/salmon#Deme</a>
 <ul>
 <li>Added: SubClass of http://rs.tdwg.org/dwc/terms/Organism</li>
+</ul>
+</li>
+<li><a href="#FisheriesReferencePointLower">https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower</a>
+<ul>
+<li>Added: SubClass of https://w3id.org/gcdfo/salmon#LimitReferencePoint</li>
 </ul>
 </li>
 <li><a href="#LowerBiologicalBenchmark">https://w3id.org/gcdfo/salmon#LowerBiologicalBenchmark</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -583,7 +583,7 @@ $(function(){
     <div id="overview"><h2 id="overv" class="list">GC DFO Salmon Ontology: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
-<h4>Classes</h4><details class="gcdfo-collapsible gcdfo-overview-collapsible"><summary>56 items (expand)</summary><ul xmlns:widoco="https://w3id.org/widoco/vocab#"
+<h4>Classes</h4><details class="gcdfo-collapsible gcdfo-overview-collapsible"><summary>57 items (expand)</summary><ul xmlns:widoco="https://w3id.org/widoco/vocab#"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     class="hlist">
    <li>
@@ -635,6 +635,10 @@ This ontology has the following classes and properties.</span>
    </li>
    <li>
       <a href="#http://purl.dataone.org/odo/SALMON_00000639" title="http://purl.dataone.org/odo/SALMON_00000639">Fish stock type</a>
+   </li>
+   <li>
+      <a href="#FisheriesReferencePointLower"
+         title="https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower">Fisheries Reference Point - Lower</a>
    </li>
    <li>
       <a href="#http://purl.dataone.org/odo/SALMON_00000137" title="http://purl.dataone.org/odo/SALMON_00000137">Fishery type</a>
@@ -2979,6 +2983,7 @@ This section provides details for each class and property defined by GC DFO Salm
   <li><a href="#ExploitationRate" title="https://w3id.org/gcdfo/salmon#ExploitationRate">Exploitation rate</a></li>
   <li><a href="#http://purl.dataone.org/odo/SALMON_00000167" title="http://purl.dataone.org/odo/SALMON_00000167">Fish measurement type</a></li>
   <li><a href="#http://purl.dataone.org/odo/SALMON_00000639" title="http://purl.dataone.org/odo/SALMON_00000639">Fish stock type</a></li>
+  <li><a href="#FisheriesReferencePointLower" title="https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower">Fisheries Reference Point - Lower</a></li>
   <li><a href="#http://purl.dataone.org/odo/SALMON_00000137" title="http://purl.dataone.org/odo/SALMON_00000137">Fishery type</a></li>
   <li><a href="#http://purl.obolibrary.org/obo/BFO_0000031" title="http://purl.obolibrary.org/obo/BFO_0000031">generically dependent continuant</a></li>
   <li><a href="#http://rs.tdwg.org/dwc/terms/Identification" title="http://rs.tdwg.org/dwc/terms/Identification">Identification</a></li>
@@ -3498,6 +3503,37 @@ This section provides details for each class and property defined by GC DFO Salm
    </dd>
   </dl>
  </div>
+ <div class="entity" id="FisheriesReferencePointLower">
+  <h3>Fisheries Reference Point - Lower<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower</p>
+  <div class="comment">
+   <span class="markdown">A lower fisheries-management reference point defined for Stock Management Units (SMUs) and related fishery decision frameworks. It may be informed by Conservation Unit (CU) lower biological benchmarks, but is not identical to CU-level lower biological benchmarks used to delineate Wild Salmon Policy biological status zones.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <dl class="definedBy">
+   <dt>
+    Source
+   </dt>
+   <dd>
+    Fisheries and Oceans Canada. (2022). Methodologies and Guidelines for Defining Limit Reference Points for Pacific Salmon. DFO Can. Sci. Advis. Sec. Sci. Advis. Rep. 2022/030. (Erratum: December 2022).
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    has super-classes
+   </dt>
+   <dd>
+    <a href="#LimitReferencePoint" title="https://w3id.org/gcdfo/salmon#LimitReferencePoint">Limit reference point</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+  </dl>
+ </div>
  <div class="entity" id="http://purl.dataone.org/odo/SALMON_00000137">
   <h3>Fishery type<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> http://purl.dataone.org/odo/SALMON_00000137</p>
@@ -3708,6 +3744,12 @@ This section provides details for each class and property defined by GC DFO Salm
    <dd>
     <a href="#ReferencePoint" title="https://w3id.org/gcdfo/salmon#ReferencePoint">Reference point</a> <sup class="type-c" title="class">c</sup>
    </dd>
+   <dt>
+    has sub-classes
+   </dt>
+   <dd>
+    <a href="#FisheriesReferencePointLower" title="https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower">Fisheries Reference Point - Lower</a> <sup class="type-c" title="class">c</sup>
+   </dd>
   </dl>
  </div>
  <div class="entity" id="http://purl.obolibrary.org/obo/ENVO_01000618">
@@ -3743,7 +3785,7 @@ This section provides details for each class and property defined by GC DFO Salm
   <h3>Lower biological benchmark<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#LowerBiologicalBenchmark</p>
   <div class="comment">
-   <span class="markdown">Lower benchmark value for a metric used to delineate Wild Salmon Policy status zones (typically the boundary between Red and Amber zones).</span>
+   <span class="markdown">Lower benchmark value for a Conservation Unit (CU) metric used to delineate Wild Salmon Policy status zones (typically the boundary between Red and Amber zones). This CU-level biological benchmark is distinct from SMU-level fisheries management lower reference points such as FRP-L.</span>
   </div>
   <dl class="definedBy">
    <dt>
@@ -4991,6 +5033,11 @@ This section provides details for each class and property defined by GC DFO Salm
 <ul><li><a href="#Deme">https://w3id.org/gcdfo/salmon#Deme</a>
 <ul>
 <li>Added: SubClass of http://rs.tdwg.org/dwc/terms/Organism</li>
+</ul>
+</li>
+<li><a href="#FisheriesReferencePointLower">https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower</a>
+<ul>
+<li>Added: SubClass of https://w3id.org/gcdfo/salmon#LimitReferencePoint</li>
 </ul>
 </li>
 <li><a href="#LowerBiologicalBenchmark">https://w3id.org/gcdfo/salmon#LowerBiologicalBenchmark</a>

--- a/draft/dfo-salmon-draft.ttl
+++ b/draft/dfo-salmon-draft.ttl
@@ -1065,7 +1065,7 @@ gcdfo:CUBenchmark a skos:Concept ;
 
 gcdfo:CULowerBenchmark a gcdfo:CUBenchmark , skos:Concept ;
   skos:prefLabel "Conservation Unit lower benchmark"@en ;
-  skos:definition "A reference point in biological status associated with significant losses in production between the Amber and Red zones, and which allows for a substantial buffer between it and any level of abundance that could lead to a CU being considered at risk of extinction."@en ;
+  skos:definition "A Conservation Unit (CU)-level biological reference point associated with significant losses in production between the Amber and Red zones, and which allows for a substantial buffer between it and any level of abundance that could lead to a CU being considered at risk of extinction. This CU benchmark is distinct from SMU-level fisheries management lower reference points such as FRP-L."@en ;
   skos:inScheme gcdfo:BiologicalBenchmarkScheme ;
   iao:0000119 "Fisheries and Oceans Canada. (2021). Wild Salmon Policy 2018-2022 Implementation Plan. Available at https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf."@en ; # definition source
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
@@ -1271,6 +1271,14 @@ gcdfo:LimitReferencePoint a owl:Class ;
   iao:0000115 "A fish stock experiencing serious harm may be depleted to the point where it has impaired productivity or reproductive capacity. As a result, the stock would be less resilient to fishing and could not easily rebuild. Serious harm may be irreversible, or only slowly reversible over the long-term, and can be due to fishing, other human-induced impacts, or natural causes. Under the Precautionary Approach policy and the Fish Stocks Provisions (FSPs), breaching the LRP is a trigger for a rebuilding plan."@en ; # definition
   rdfs:subClassOf gcdfo:ReferencePoint ;
   iao:0000119 "Fisheries and Oceans Canada. (2024). Introduction to Stock Assessment - Glossary. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html. [Accessed 09-10-2025]."@en ; # definition source
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+
+gcdfo:FisheriesReferencePointLower a owl:Class ;
+  rdfs:label "Fisheries Reference Point - Lower"@en ;
+  skos:altLabel "FRP-L"@en ;
+  iao:0000115 "A lower fisheries-management reference point defined for Stock Management Units (SMUs) and related fishery decision frameworks. It may be informed by Conservation Unit (CU) lower biological benchmarks, but is not identical to CU-level lower biological benchmarks used to delineate Wild Salmon Policy biological status zones."@en ; # definition
+  rdfs:subClassOf gcdfo:LimitReferencePoint ;
+  iao:0000119 "Fisheries and Oceans Canada. (2022). Methodologies and Guidelines for Defining Limit Reference Points for Pacific Salmon. DFO Can. Sci. Advis. Sec. Sci. Advis. Rep. 2022/030. (Erratum: December 2022)."@en ; # definition source
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
 
 gcdfo:MarineSurvival a owl:Class ;
@@ -3170,6 +3178,7 @@ gcdfo:Extinct gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:SpeciesAtRiskRecove
 gcdfo:Extirpated gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:SpeciesAtRiskRecoveryTheme .
 gcdfo:Fecundity gcdfo:theme gcdfo:StockAssessmentTheme .
 gcdfo:FisheryReferencePoint gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:FisheriesManagementTheme .
+gcdfo:FisheriesReferencePointLower gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:FisheriesManagementTheme , gcdfo:PolicyGovernanceTheme .
 gcdfo:FishingEffort gcdfo:theme gcdfo:StockAssessmentTheme , gcdfo:FisheriesManagementTheme , gcdfo:PolicyGovernanceTheme .
 gcdfo:FishingMortality gcdfo:theme gcdfo:FisheriesManagementTheme , gcdfo:PolicyGovernanceTheme .
 gcdfo:FixedStationCountAnalysis gcdfo:theme gcdfo:MonitoringFieldWorkTheme .
@@ -3445,6 +3454,7 @@ gcdfo:EscapementSurveyEvent gcdfo:publicationStatus gcdfo:PublishReady .
 gcdfo:EscapementMeasurement gcdfo:publicationStatus gcdfo:PublishReady .
 gcdfo:ReferencePoint gcdfo:publicationStatus gcdfo:PublishReady .
 gcdfo:LimitReferencePoint gcdfo:publicationStatus gcdfo:PublishReady .
+gcdfo:FisheriesReferencePointLower gcdfo:publicationStatus gcdfo:PublishReady .
 gcdfo:UpperStockReferencePoint gcdfo:publicationStatus gcdfo:PublishReady .
 gcdfo:WSPBiologicalStatusZone gcdfo:publicationStatus gcdfo:PublishReady .
 gcdfo:GreenZone gcdfo:publicationStatus gcdfo:PublishReady .

--- a/ontology/dfo-salmon.ttl
+++ b/ontology/dfo-salmon.ttl
@@ -1546,6 +1546,15 @@ gcdfo:LimitReferencePoint a owl:Class ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:FisheriesManagementTheme, gcdfo:PolicyGovernanceTheme ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
 
+gcdfo:FisheriesReferencePointLower a owl:Class ;
+  rdfs:label "Fisheries Reference Point - Lower"@en ;
+  skos:altLabel "FRP-L"@en ;
+  iao:0000115 "A lower fisheries-management reference point defined for Stock Management Units (SMUs) and related fishery decision frameworks. It may be informed by Conservation Unit (CU) lower biological benchmarks, but is not identical to CU-level lower biological benchmarks used to delineate Wild Salmon Policy biological status zones."@en ; # definition
+  rdfs:subClassOf gcdfo:LimitReferencePoint ;
+  iao:0000119 "Fisheries and Oceans Canada. (2022). Methodologies and Guidelines for Defining Limit Reference Points for Pacific Salmon. DFO Can. Sci. Advis. Sec. Sci. Advis. Rep. 2022/030. (Erratum: December 2022)."@en ; # definition source
+  gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:FisheriesManagementTheme, gcdfo:PolicyGovernanceTheme ;
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+
 gcdfo:UpperStockReferencePoint a owl:Class ;
   rdfs:label "Upper stock reference"@en ;
   iao:0000115 "A threshold below which fishing must be reduced to avoid reaching the LRP. The USR must be set at an appropriate distance above the LRP to provide sufficient opportunity for managers to recognize a declining stock status and sufficient time for management actions to take effect. "@en ; # definition
@@ -1605,7 +1614,7 @@ gcdfo:MetricBenchmark a owl:Class ;
 
 gcdfo:LowerBiologicalBenchmark a owl:Class ;
   rdfs:label "Lower biological benchmark"@en ;
-  iao:0000115 "Lower benchmark value for a metric used to delineate Wild Salmon Policy status zones (typically the boundary between Red and Amber zones)."@en ; # definition
+  iao:0000115 "Lower benchmark value for a Conservation Unit (CU) metric used to delineate Wild Salmon Policy status zones (typically the boundary between Red and Amber zones). This CU-level biological benchmark is distinct from SMU-level fisheries management lower reference points such as FRP-L."@en ; # definition
   iao:0000119 "Fisheries and Oceans Canada. (2021). Wild Salmon Policy 2018-2022 Implementation Plan. Available at https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf."@en ; # definition source
   dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf> ;
   rdfs:subClassOf gcdfo:MetricBenchmark ;


### PR DESCRIPTION
## Summary
Implements Brett's FRP-L modeling direction by introducing an explicit SMU-level lower fisheries reference-point term and keeping CU-level lower biological benchmarks distinct.

Closes #41.

## Changes
- Added `gcdfo:FisheriesReferencePointLower` in:
  - `ontology/dfo-salmon.ttl`
  - `draft/dfo-salmon-draft.ttl`
- Added labels/metadata:
  - `rdfs:label "Fisheries Reference Point - Lower"@en`
  - `skos:altLabel "FRP-L"@en`
  - `rdfs:subClassOf gcdfo:LimitReferencePoint`
  - definition explicitly scoped to SMU/fisheries-management context and explicitly distinct from CU lower biological benchmarks
- Clarified CU-specific benchmark context to avoid conflation:
  - `ontology`: updated `gcdfo:LowerBiologicalBenchmark` definition
  - `draft`: updated `gcdfo:CULowerBenchmark` definition
- Added draft metadata entries for new term:
  - `gcdfo:theme ...`
  - `gcdfo:publicationStatus gcdfo:PublishReady`
- Refreshed generated docs/artifacts via CI (`docs/gcdfo.*`, `docs/index*.html`).

## Validation
- Ran full CI/docs refresh:
  - `make ci` (with `JAVA_HOME` + `PATH` set to Homebrew `openjdk@11`)
