### PR TITLE
docs: disambiguate changelog object-properties TOC label

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7152,7 +7152,7 @@ This section provides details for each class and property defined by DFO Salmon 
 </li>
 <li><a href="#YearBasis">https://w3id.org/gcdfo/salmon#YearBasis</a>
 </li>
-</ul></details><h3 id="changeProp" class="list">Object Properties</h3>
+</ul></details><h3 id="changeProp" class="list">Object Properties (changes)</h3>
 <details><summary><u>Added object properties</u></summary>
 <ul><li><a href="#http://www.w3.org/ns/prov#generated">http://www.w3.org/ns/prov#generated</a>
 </li>

--- a/scripts/generate_skos_section.py
+++ b/scripts/generate_skos_section.py
@@ -578,10 +578,14 @@ def ensure_custom_ui_enhancements() -> None:
             1,
         )
 
-    # Avoid confusing duplicate TOC labels ("Classes" appears in Crossref and again in the changelog).
+    # Avoid confusing duplicate TOC labels (Crossref labels repeat in the changelog section).
     content = content.replace(
         '<h3 id="changeClass" class="list">Classes</h3>',
         '<h3 id="changeClass" class="list">Classes (changes)</h3>',
+    )
+    content = content.replace(
+        '<h3 id="changeProp" class="list">Object Properties</h3>',
+        '<h3 id="changeProp" class="list">Object Properties (changes)</h3>',
     )
 
     # WebVOWL embed: wrap the generated iframe in a collapsible to keep the Overview compact.


### PR DESCRIPTION
## Summary
- update WIDOCO post-process so changelog object properties heading is rewritten to `Object Properties (changes)`
- update current generated docs output to match

## Why
- avoids duplicate TOC labels between Cross-reference and Changes sections

## Scope
- docs-only, no ontology term changes
