### PR TITLE
fix: reconnect process branch to core assessment graph (#40)

### DIFF
--- a/docs/COMPETENCY_QUESTIONS.md
+++ b/docs/COMPETENCY_QUESTIONS.md
@@ -45,6 +45,64 @@ SELECT ?variable ?property ?entity ?constraint ?procedure WHERE {
 ORDER BY ?variable ?property ?entity ?constraint ?procedure
 ```
 
+## Process ↔ Assessment Bridge (Issue #40)
+
+- **CQ-Process-1:** Which assessment processes evaluate which stocks/CUs/SMUs/populations?
+
+```sparql
+SELECT ?assessment ?subject WHERE {
+  ?assessment a gcdfo:StockAssessment ;
+              gcdfo:hasAssessmentSubject ?subject .
+}
+ORDER BY ?assessment ?subject
+```
+
+- **CQ-Process-2:** Which measurement/rate data are used by each stock assessment?
+
+```sparql
+SELECT ?assessment ?datum WHERE {
+  ?assessment a gcdfo:StockAssessment ;
+              gcdfo:usesAssessmentDatum ?datum .
+  ?datum a iao:0000109 .
+}
+ORDER BY ?assessment ?datum
+```
+
+- **CQ-Process-3:** Which management reference points are explicitly tied to each stock assessment?
+
+```sparql
+SELECT ?assessment ?referencePoint WHERE {
+  ?assessment a gcdfo:StockAssessment ;
+              gcdfo:hasAssessmentReferencePoint ?referencePoint .
+}
+ORDER BY ?assessment ?referencePoint
+```
+
+- **CQ-Process-4:** Which survey events produce results that flow into stock assessments?
+
+```sparql
+SELECT ?surveyEvent ?datum ?assessment WHERE {
+  ?surveyEvent a gcdfo:SurveyEvent ;
+               gcdfo:hasObservationResult ?datum .
+  ?datum gcdfo:isDatumUsedInAssessment ?assessment .
+}
+ORDER BY ?surveyEvent ?assessment
+```
+
+- **CQ-Process-5:** For each assessment subject, what is the end-to-end path from field process -> datum -> assessment -> reference point?
+
+```sparql
+SELECT ?subject ?surveyEvent ?datum ?assessment ?referencePoint WHERE {
+  ?assessment a gcdfo:StockAssessment ;
+              gcdfo:hasAssessmentSubject ?subject ;
+              gcdfo:hasAssessmentReferencePoint ?referencePoint .
+  ?surveyEvent a gcdfo:SurveyEvent ;
+               gcdfo:hasObservationResult ?datum .
+  ?datum gcdfo:isDatumUsedInAssessment ?assessment .
+}
+ORDER BY ?subject ?assessment ?surveyEvent
+```
+
 ## Genetic Results
 
 ## FSARs

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1599,6 +1599,30 @@ SELECT ?method ?stock ?event WHERE {
     owl:disjointWith :Freshwater .
 ```
 
+#### 6.3.4 Controlled disconnection vs required bridge edges
+
+**Principle:** not every module must be fully connected, but any process-heavy branch that supports stock-assessment or management workflows **must** expose at least one explicit bridge to core assessment concepts.
+
+**Disconnection is acceptable when all are true:**
+
+- The branch is intentionally modular (for example, a staging/alignment-only slice)
+- It has clear scope notes indicating deferred integration
+- No competency question depends on traversal from that branch to assessment/management classes
+
+**Bridge edges are required when any are true:**
+
+- The branch contains process classes (`bfo:0000015` descendants) used in assessment workflows
+- Review/decision use-cases require joining process, measurement, and reference-point context
+- A branch would otherwise be isolated from `gcdfo:StockAssessment` and related assessment concepts
+
+**Minimum bridge expectation (issue #40 closure pattern):**
+
+- process/assessment -> assessed subject (`gcdfo:hasAssessmentSubject`)
+- process/assessment -> measurement datum (`gcdfo:usesAssessmentDatum`)
+- process/assessment -> reference point (`gcdfo:hasAssessmentReferencePoint`)
+
+Use inverse properties where they materially improve query ergonomics.
+
 ### 6.4 Membership and Roll-up Pattern (SMU ▶ CU ▶ Population)
 
 **What is the membership pattern?** This pattern represents the hierarchical relationship between Stock Management Units, Conservation Units, and Populations in salmon management.

--- a/docs/analyses/2026-03-02-issue-40-process-bridge.md
+++ b/docs/analyses/2026-03-02-issue-40-process-bridge.md
@@ -1,0 +1,87 @@
+# Issue #40 — Process-branch disconnect reproduction and bridge verification
+
+## Scope
+
+Issue: <https://github.com/dfo-pacific-science/dfo-salmon-ontology/issues/40>
+
+Goal: verify the process-branch disconnect on `origin/main`, then confirm the minimal bridge patch reconnects process classes to assessment/measurement/reference-point classes.
+
+## Reproduction method (schema-level graph walk)
+
+`ontology/dfo-salmon.ttl` was parsed with `rdflib` and inspected as a class graph where edges come from object-property `rdfs:domain -> rdfs:range` axioms (including `owl:unionOf` expansions).
+
+Process branch seed: `bfo:0000015` and all subclasses.
+
+Targets checked:
+
+- `gcdfo:StockAssessment`
+- `gcdfo:ReferencePoint`
+- `gcdfo:ObservedRateOrAbundance`
+- `gcdfo:TargetOrLimitRateOrAbundance`
+- `iao:0000109` (measurement datum)
+
+## Baseline on `origin/main` (before patch)
+
+Process subclasses detected (8):
+
+- `bfo:0000015`
+- `dwc:Event`
+- `dwc:Occurrence`
+- `dwc:Identification`
+- `gcdfo:SurveyEvent`
+- `gcdfo:EscapementSurveyEvent`
+- `gcdfo:Escapement`
+- `gcdfo:StockAssessment`
+
+Object properties touching the process branch: **4**
+
+- `gcdfo:hasFeatureOfInterest`
+- `gcdfo:hasObservationResult`
+- `gcdfo:hasObservedVariable`
+- `gcdfo:usesObservationProcedure`
+
+Reachability from process branch to targets (domain/range walk):
+
+- `StockAssessment`: **False**
+- `ReferencePoint`: **False**
+- `ObservedRateOrAbundance`: **False**
+- `TargetOrLimitRateOrAbundance`: **False**
+- `iao:0000109`: **False**
+
+Interpretation: process connectivity existed only around `SurveyEvent`, with no explicit bridge into core stock-assessment + management-reference structure.
+
+## Patch verification (current branch)
+
+New bridge properties introduced:
+
+- `gcdfo:hasAssessmentSubject` / `gcdfo:isAssessmentSubjectOf`
+- `gcdfo:usesAssessmentDatum` / `gcdfo:isDatumUsedInAssessment`
+- `gcdfo:hasAssessmentReferencePoint` / `gcdfo:isAssessmentReferencePointFor`
+
+Process-touching object properties after patch: **10**
+
+Reachability from process branch to targets after patch:
+
+- `StockAssessment`: **True**
+- `ReferencePoint`: **True**
+- `ObservedRateOrAbundance`: **True**
+- `TargetOrLimitRateOrAbundance`: **True**
+- `iao:0000109`: **True**
+
+## Example inferable paths enabled
+
+1. `gcdfo:SurveyEvent`
+   → `gcdfo:hasObservationResult`
+   → `gcdfo:EscapementMeasurement`
+   → `gcdfo:isDatumUsedInAssessment`
+   → `gcdfo:StockAssessment`
+
+2. `gcdfo:StockAssessment`
+   → `gcdfo:hasAssessmentSubject`
+   → `gcdfo:ReportingOrManagementStratum` / `gcdfo:Population`
+
+3. `gcdfo:StockAssessment`
+   → `gcdfo:hasAssessmentReferencePoint`
+   → `gcdfo:ReferencePoint`
+
+This closes the process-branch disconnect described in #40 while keeping the bridge surface intentionally small.

--- a/docs/gcdfo.jsonld
+++ b/docs/gcdfo.jsonld
@@ -27,6 +27,54 @@
     ]
   },
   {
+    "@id": "_:b2",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum"
+          },
+          {
+            "@id": "https://w3id.org/gcdfo/salmon#Population"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:b3",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum"
+          },
+          {
+            "@id": "https://w3id.org/gcdfo/salmon#Population"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:b4",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://purl.obolibrary.org/obo/IAO_0000109"
+          },
+          {
+            "@id": "https://w3id.org/gcdfo/salmon#ObservedRateOrAbundance"
+          },
+          {
+            "@id": "https://w3id.org/gcdfo/salmon#TargetOrLimitRateOrAbundance"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "@id": "http://purl.dataone.org/odo/ECSO_00002050",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -1199,7 +1247,7 @@
     "http://purl.org/dc/terms/modified": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2026-02-24"
+        "@value": "2026-03-02"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -10232,6 +10280,109 @@
     ]
   },
   {
+    "@id": "https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000115": [
+      {
+        "@language": "en",
+        "@value": "Relates a stock assessment process to a reference point used to interpret status or management risk."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessment"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has assessment reference point"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#ReferencePoint"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "http://www.w3.org/ns/prov#used"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor"
+      }
+    ],
+    "https://w3id.org/gcdfo/salmon#theme": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessmentTheme"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/gcdfo/salmon#hasAssessmentSubject",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000115": [
+      {
+        "@language": "en",
+        "@value": "Relates a stock-assessment process to the reporting/management stratum or biological population it evaluates."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessment"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has assessment subject"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "_:b2"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf"
+      }
+    ],
+    "https://w3id.org/gcdfo/salmon#theme": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessmentTheme"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/gcdfo/salmon#hasConservationUnit",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
@@ -10689,6 +10840,150 @@
     ]
   },
   {
+    "@id": "https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000115": [
+      {
+        "@language": "en",
+        "@value": "Relates a reference point to a stock assessment process that uses it for status interpretation or advice."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#ReferencePoint"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "is assessment reference point for"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessment"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint"
+      }
+    ],
+    "https://w3id.org/gcdfo/salmon#theme": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessmentTheme"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000115": [
+      {
+        "@language": "en",
+        "@value": "Relates a reporting/management stratum or biological population to a stock assessment that evaluates it."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "_:b3"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "is assessment subject of"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessment"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#hasAssessmentSubject"
+      }
+    ],
+    "https://w3id.org/gcdfo/salmon#theme": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessmentTheme"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000115": [
+      {
+        "@language": "en",
+        "@value": "Relates a measurement datum to a stock assessment process that uses it as evidence."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://purl.obolibrary.org/obo/IAO_0000109"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "is datum used in assessment"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessment"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#usesAssessmentDatum"
+      }
+    ],
+    "https://w3id.org/gcdfo/salmon#theme": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessmentTheme"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/gcdfo/salmon#isSampleOfStratum",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
@@ -10888,6 +11183,63 @@
     "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
       {
         "@id": "http://www.w3.org/ns/sosa/usedProcedure"
+      }
+    ],
+    "https://w3id.org/gcdfo/salmon#theme": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessmentTheme"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/gcdfo/salmon#usesAssessmentDatum",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000115": [
+      {
+        "@language": "en",
+        "@value": "Relates a stock assessment to a measurement datum used as assessment input or evidence."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@language": "en",
+        "@value": "Range explicitly includes measurement datum plus common rate classes used in stock-assessment workflows."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessment"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "uses assessment datum"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "_:b4"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "http://www.w3.org/ns/prov#used"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment"
       }
     ],
     "https://w3id.org/gcdfo/salmon#theme": [

--- a/docs/gcdfo.owl
+++ b/docs/gcdfo.owl
@@ -35,7 +35,7 @@
         <dcterms:creator xml:lang="en">Fishery &amp; Assessment Data Section (FADS) Data Stewardship Unit</dcterms:creator>
         <dcterms:description xml:lang="en">OWL + SKOS ontology for DFO salmon data: stocks/CUs/MUs, survey events, escapement measurements, and GSI constructs; aligns to DwC via rdfs:subClassOf; hybrid approach with SKOS for methods and OWL for events.</dcterms:description>
         <dcterms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2026-02-24</dcterms:modified>
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2026-03-02</dcterms:modified>
         <dcterms:publisher xml:lang="en">Fisheries and Oceans Canada (DFO) Pacific Region Science Branch</dcterms:publisher>
         <dcterms:title xml:lang="en">DFO Salmon Ontology</dcterms:title>
         <vann:preferredNamespacePrefix>gcdfo</vann:preferredNamespacePrefix>
@@ -441,6 +441,46 @@
     
 
 
+    <!-- https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#used"/>
+        <owl:inverseOf rdf:resource="https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor"/>
+        <rdfs:domain rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessment"/>
+        <rdfs:range rdf:resource="https://w3id.org/gcdfo/salmon#ReferencePoint"/>
+        <obo:IAO_0000115 xml:lang="en">Relates a stock assessment process to a reference point used to interpret status or management risk.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">has assessment reference point</rdfs:label>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/gcdfo/salmon#hasAssessmentSubject -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">
+        <owl:inverseOf rdf:resource="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf"/>
+        <rdfs:domain rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessment"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://w3id.org/gcdfo/salmon#Population"/>
+                    <rdf:Description rdf:about="https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+        <obo:IAO_0000115 xml:lang="en">Relates a stock-assessment process to the reporting/management stratum or biological population it evaluates.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">has assessment subject</rdfs:label>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/gcdfo/salmon#hasConservationUnit -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/gcdfo/salmon#hasConservationUnit">
@@ -575,6 +615,58 @@
     
 
 
+    <!-- https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor">
+        <rdfs:domain rdf:resource="https://w3id.org/gcdfo/salmon#ReferencePoint"/>
+        <rdfs:range rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessment"/>
+        <obo:IAO_0000115 xml:lang="en">Relates a reference point to a stock assessment process that uses it for status interpretation or advice.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">is assessment reference point for</rdfs:label>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://w3id.org/gcdfo/salmon#Population"/>
+                    <rdf:Description rdf:about="https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+        <rdfs:range rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessment"/>
+        <obo:IAO_0000115 xml:lang="en">Relates a reporting/management stratum or biological population to a stock assessment that evaluates it.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">is assessment subject of</rdfs:label>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment">
+        <owl:inverseOf rdf:resource="https://w3id.org/gcdfo/salmon#usesAssessmentDatum"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000109"/>
+        <rdfs:range rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessment"/>
+        <obo:IAO_0000115 xml:lang="en">Relates a measurement datum to a stock assessment process that uses it as evidence.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">is datum used in assessment</rdfs:label>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/gcdfo/salmon#isSampleOfStratum -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/gcdfo/salmon#isSampleOfStratum">
@@ -625,6 +717,30 @@
 
     <owl:ObjectProperty rdf:about="https://w3id.org/gcdfo/salmon#usedProcedure">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sosa/usedProcedure"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/gcdfo/salmon#usesAssessmentDatum -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#used"/>
+        <rdfs:domain rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessment"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000109"/>
+                    <rdf:Description rdf:about="https://w3id.org/gcdfo/salmon#ObservedRateOrAbundance"/>
+                    <rdf:Description rdf:about="https://w3id.org/gcdfo/salmon#TargetOrLimitRateOrAbundance"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+        <obo:IAO_0000115 xml:lang="en">Relates a stock assessment to a measurement datum used as assessment input or evidence.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Range explicitly includes measurement datum plus common rate classes used in stock-assessment workflows.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">uses assessment datum</rdfs:label>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
     </owl:ObjectProperty>
     
 

--- a/docs/gcdfo.ttl
+++ b/docs/gcdfo.ttl
@@ -35,7 +35,7 @@
                                  dcterms:creator "Fishery & Assessment Data Section (FADS) Data Stewardship Unit"@en ;
                                  dcterms:description "OWL + SKOS ontology for DFO salmon data: stocks/CUs/MUs, survey events, escapement measurements, and GSI constructs; aligns to DwC via rdfs:subClassOf; hybrid approach with SKOS for methods and OWL for events."@en ;
                                  dcterms:license <https://creativecommons.org/licenses/by/4.0/> ;
-                                 dcterms:modified "2026-02-24"^^xsd:date ;
+                                 dcterms:modified "2026-03-02"^^xsd:date ;
                                  dcterms:publisher "Fisheries and Oceans Canada (DFO) Pacific Region Science Branch"@en ;
                                  dcterms:title "DFO Salmon Ontology"@en ;
                                  vann:preferredNamespacePrefix "gcdfo" ;
@@ -306,6 +306,37 @@ gcdfo:demeOf rdf:type owl:ObjectProperty ;
                          gcdfo:WildSalmonPolicyTheme .
 
 
+###  https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint
+gcdfo:hasAssessmentReferencePoint rdf:type owl:ObjectProperty ;
+                                  rdfs:subPropertyOf prov:used ;
+                                  owl:inverseOf gcdfo:isAssessmentReferencePointFor ;
+                                  rdfs:domain gcdfo:StockAssessment ;
+                                  rdfs:range gcdfo:ReferencePoint ;
+                                  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a stock assessment process to a reference point used to interpret status or management risk."@en ;
+                                  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                  rdfs:label "has assessment reference point"@en ;
+                                  gcdfo:theme gcdfo:FisheriesManagementTheme ,
+                                              gcdfo:PolicyGovernanceTheme ,
+                                              gcdfo:StockAssessmentTheme .
+
+
+###  https://w3id.org/gcdfo/salmon#hasAssessmentSubject
+gcdfo:hasAssessmentSubject rdf:type owl:ObjectProperty ;
+                           owl:inverseOf gcdfo:isAssessmentSubjectOf ;
+                           rdfs:domain gcdfo:StockAssessment ;
+                           rdfs:range [ rdf:type owl:Class ;
+                                        owl:unionOf ( gcdfo:Population
+                                                      gcdfo:ReportingOrManagementStratum
+                                                    )
+                                      ] ;
+                           <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a stock-assessment process to the reporting/management stratum or biological population it evaluates."@en ;
+                           rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                           rdfs:label "has assessment subject"@en ;
+                           gcdfo:theme gcdfo:DataModelProvenanceTheme ,
+                                       gcdfo:PolicyGovernanceTheme ,
+                                       gcdfo:StockAssessmentTheme .
+
+
 ###  https://w3id.org/gcdfo/salmon#hasConservationUnit
 gcdfo:hasConservationUnit rdf:type owl:ObjectProperty ;
                           rdfs:domain gcdfo:StockManagementUnit ;
@@ -413,6 +444,46 @@ gcdfo:hasYearBasis rdf:type owl:ObjectProperty ;
                                gcdfo:StockAssessmentTheme .
 
 
+###  https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor
+gcdfo:isAssessmentReferencePointFor rdf:type owl:ObjectProperty ;
+                                    rdfs:domain gcdfo:ReferencePoint ;
+                                    rdfs:range gcdfo:StockAssessment ;
+                                    <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a reference point to a stock assessment process that uses it for status interpretation or advice."@en ;
+                                    rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                    rdfs:label "is assessment reference point for"@en ;
+                                    gcdfo:theme gcdfo:FisheriesManagementTheme ,
+                                                gcdfo:PolicyGovernanceTheme ,
+                                                gcdfo:StockAssessmentTheme .
+
+
+###  https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf
+gcdfo:isAssessmentSubjectOf rdf:type owl:ObjectProperty ;
+                            rdfs:domain [ rdf:type owl:Class ;
+                                          owl:unionOf ( gcdfo:Population
+                                                        gcdfo:ReportingOrManagementStratum
+                                                      )
+                                        ] ;
+                            rdfs:range gcdfo:StockAssessment ;
+                            <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a reporting/management stratum or biological population to a stock assessment that evaluates it."@en ;
+                            rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                            rdfs:label "is assessment subject of"@en ;
+                            gcdfo:theme gcdfo:DataModelProvenanceTheme ,
+                                        gcdfo:PolicyGovernanceTheme ,
+                                        gcdfo:StockAssessmentTheme .
+
+
+###  https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment
+gcdfo:isDatumUsedInAssessment rdf:type owl:ObjectProperty ;
+                              owl:inverseOf gcdfo:usesAssessmentDatum ;
+                              rdfs:domain <http://purl.obolibrary.org/obo/IAO_0000109> ;
+                              rdfs:range gcdfo:StockAssessment ;
+                              <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a measurement datum to a stock assessment process that uses it as evidence."@en ;
+                              rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                              rdfs:label "is datum used in assessment"@en ;
+                              gcdfo:theme gcdfo:DataModelProvenanceTheme ,
+                                          gcdfo:StockAssessmentTheme .
+
+
 ###  https://w3id.org/gcdfo/salmon#isSampleOfStratum
 gcdfo:isSampleOfStratum rdf:type owl:ObjectProperty ;
                         rdfs:subPropertyOf prov:wasDerivedFrom ,
@@ -453,6 +524,24 @@ gcdfo:populationOf rdf:type owl:ObjectProperty ;
 ###  https://w3id.org/gcdfo/salmon#usedProcedure
 gcdfo:usedProcedure rdf:type owl:ObjectProperty ;
                     rdfs:subPropertyOf sosa:usedProcedure .
+
+
+###  https://w3id.org/gcdfo/salmon#usesAssessmentDatum
+gcdfo:usesAssessmentDatum rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf prov:used ;
+                          rdfs:domain gcdfo:StockAssessment ;
+                          rdfs:range [ rdf:type owl:Class ;
+                                       owl:unionOf ( <http://purl.obolibrary.org/obo/IAO_0000109>
+                                                     gcdfo:ObservedRateOrAbundance
+                                                     gcdfo:TargetOrLimitRateOrAbundance
+                                                   )
+                                     ] ;
+                          <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a stock assessment to a measurement datum used as assessment input or evidence."@en ;
+                          rdfs:comment "Range explicitly includes measurement datum plus common rate classes used in stock-assessment workflows."@en ;
+                          rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                          rdfs:label "uses assessment datum"@en ;
+                          gcdfo:theme gcdfo:DataModelProvenanceTheme ,
+                                      gcdfo:StockAssessmentTheme .
 
 
 ###  https://w3id.org/gcdfo/salmon#usesObservationProcedure

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -17,7 +17,7 @@
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"https://w3id.org/gcdfo/salmon#","image":"http://vowl.visualdataweb.org/webvowl/#iri=https://w3id.org/gcdfo/salmon#","name":"DFO Salmon Ontology", "headline":"Document describing the ontology https://w3id.org/gcdfo/salmon#", "dateReleased":"2025-09-06", "dateModified":"2026-02-24", "version":"0.0.6-alpha (integrated pre-release review branch)", "license":"https://creativecommons.org/licenses/by/4.0/", "codeRepository":"https://github.com/dfo-pacific-science/dfo-salmon-ontology", "author":[{"@type":"Person","name":"Fishery & Assessment Data Section (FADS) Data Stewardship Unit"}], "contributor":[{"@type":"Person","name":"Brett Johnson"},{"@type":"Person","name":"Melissa K. Morrison"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"https://w3id.org/gcdfo/salmon#","image":"http://vowl.visualdataweb.org/webvowl/#iri=https://w3id.org/gcdfo/salmon#","name":"DFO Salmon Ontology", "headline":"Document describing the ontology https://w3id.org/gcdfo/salmon#", "dateReleased":"2025-09-06", "dateModified":"2026-03-02", "version":"0.0.6-alpha (integrated pre-release review branch)", "license":"https://creativecommons.org/licenses/by/4.0/", "codeRepository":"https://github.com/dfo-pacific-science/dfo-salmon-ontology", "author":[{"@type":"Person","name":"Fishery & Assessment Data Section (FADS) Data Stewardship Unit"}], "contributor":[{"@type":"Person","name":"Brett Johnson"},{"@type":"Person","name":"Melissa K. Morrison"}]}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -71,7 +71,7 @@ $(function(){
 
 
 <dl>
-<dt>Modified on: 2026-02-24</dt>
+<dt>Modified on: 2026-03-02</dt>
 <dt>This version:</dt>
 <dd><a href="https://w3id.org/gcdfo/salmon/0.0.6-alpha">https://w3id.org/gcdfo/salmon/0.0.6-alpha</a></dd>
 <dt>Previous version:</dt>
@@ -404,6 +404,14 @@ This ontology has the following classes and properties.</span>
       <a href="#demeOf" title="https://w3id.org/gcdfo/salmon#demeOf">deme of</a>
    </li>
    <li>
+      <a href="#hasAssessmentReferencePoint"
+         title="https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint">has assessment reference point</a>
+   </li>
+   <li>
+      <a href="#hasAssessmentSubject"
+         title="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">has assessment subject</a>
+   </li>
+   <li>
       <a href="#hasConservationUnit"
          title="https://w3id.org/gcdfo/salmon#hasConservationUnit">has Conservation Unit</a>
    </li>
@@ -436,6 +444,18 @@ This ontology has the following classes and properties.</span>
       <a href="#http://www.w3.org/ns/dqv#inDimension" title="http://www.w3.org/ns/dqv#inDimension">in dimension</a>
    </li>
    <li>
+      <a href="#isAssessmentReferencePointFor"
+         title="https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor">is assessment reference point for</a>
+   </li>
+   <li>
+      <a href="#isAssessmentSubjectOf"
+         title="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">is assessment subject of</a>
+   </li>
+   <li>
+      <a href="#isDatumUsedInAssessment"
+         title="https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment">is datum used in assessment</a>
+   </li>
+   <li>
       <a href="#isSampleOfStratum" title="https://w3id.org/gcdfo/salmon#isSampleOfStratum">is sample of stratum</a>
    </li>
    <li>
@@ -449,6 +469,10 @@ This ontology has the following classes and properties.</span>
       <a href="#usedProcedure" title="https://w3id.org/gcdfo/salmon#usedProcedure">
          <span>used procedure</span>
       </a>
+   </li>
+   <li>
+      <a href="#usesAssessmentDatum"
+         title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a>
    </li>
    <li>
       <a href="#usesObservationProcedure"
@@ -1546,6 +1570,18 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="#EscapementMeasurement" title="https://w3id.org/gcdfo/salmon#EscapementMeasurement">Escapement measurement</a> <sup class="type-c" title="class">c</sup>, <a href="#ExploitationRate" title="https://w3id.org/gcdfo/salmon#ExploitationRate">Exploitation rate</a> <sup class="type-c" title="class">c</sup>, <a href="#ObservedRateOrAbundance" title="https://w3id.org/gcdfo/salmon#ObservedRateOrAbundance">Observed rate or abundance</a> <sup class="type-c" title="class">c</sup>, <a href="#http://purl.dataone.org/odo/SALMON_00000479" title="http://purl.dataone.org/odo/SALMON_00000479">Salmon escapement count</a> <sup class="type-c" title="class">c</sup>, <a href="#TargetOrLimitRateOrAbundance" title="https://w3id.org/gcdfo/salmon#TargetOrLimitRateOrAbundance">Target or limit rate or abundance</a> <sup class="type-c" title="class">c</sup>, <a href="#http://purl.dataone.org/odo/ECSO_00002050" title="http://purl.dataone.org/odo/ECSO_00002050">year of measurement</a> <sup class="type-c" title="class">c</sup>
    </dd>
+   <dt>
+    is in domain of
+   </dt>
+   <dd>
+    <a href="#isDatumUsedInAssessment" title="https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment">is datum used in assessment</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#usesAssessmentDatum" title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
   </dl>
  </div>
  <div class="entity" id="MetricBenchmark">
@@ -1666,6 +1702,12 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="#CWTMarineSurvivalRate" title="https://w3id.org/gcdfo/salmon#CWTMarineSurvivalRate">CWT marine survival rate</a> <sup class="type-c" title="class">c</sup>, <a href="#InRiverMortalityRate" title="https://w3id.org/gcdfo/salmon#InRiverMortalityRate">In-river mortality rate</a> <sup class="type-c" title="class">c</sup>, <a href="#MainstemMortalityRate" title="https://w3id.org/gcdfo/salmon#MainstemMortalityRate">Mainstem mortality rate</a> <sup class="type-c" title="class">c</sup>, <a href="#MarineSurvivalIndex" title="https://w3id.org/gcdfo/salmon#MarineSurvivalIndex">Marine survival index</a> <sup class="type-c" title="class">c</sup>, <a href="#ObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#ObservedExploitationRate">Observed exploitation rate</a> <sup class="type-c" title="class">c</sup>, <a href="#OceanMortalityRate" title="https://w3id.org/gcdfo/salmon#OceanMortalityRate">Ocean mortality rate</a> <sup class="type-c" title="class">c</sup>, <a href="#ProportionHatcheryOriginSpawners" title="https://w3id.org/gcdfo/salmon#ProportionHatcheryOriginSpawners">Proportion of hatchery-origin spawners</a> <sup class="type-c" title="class">c</sup>, <a href="#SpawnerAbundance" title="https://w3id.org/gcdfo/salmon#SpawnerAbundance">Spawner abundance</a> <sup class="type-c" title="class">c</sup>, <a href="#SpawnerAbundanceChange" title="https://w3id.org/gcdfo/salmon#SpawnerAbundanceChange">Spawner abundance change</a> <sup class="type-c" title="class">c</sup>, <a href="#SpawnerAbundancePercentile" title="https://w3id.org/gcdfo/salmon#SpawnerAbundancePercentile">Spawner abundance percentile</a> <sup class="type-c" title="class">c</sup>, <a href="#SpawnerAbundanceTrend" title="https://w3id.org/gcdfo/salmon#SpawnerAbundanceTrend">Spawner abundance trend</a> <sup class="type-c" title="class">c</sup>, <a href="#TerminalMortalityRate" title="https://w3id.org/gcdfo/salmon#TerminalMortalityRate">Terminal mortality rate</a> <sup class="type-c" title="class">c</sup>, <a href="#TotalMortalityRate" title="https://w3id.org/gcdfo/salmon#TotalMortalityRate">Total mortality rate</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#usesAssessmentDatum" title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -1848,13 +1890,13 @@ This section provides details for each class and property defined by DFO Salmon 
     is in domain of
    </dt>
    <dd>
-    <a href="#hasDeme" title="https://w3id.org/gcdfo/salmon#hasDeme">has deme</a> <sup class="type-op" title="object property">op</sup>, <a href="#populationOf" title="https://w3id.org/gcdfo/salmon#populationOf">population of</a> <sup class="type-op" title="object property">op</sup>
+    <a href="#hasDeme" title="https://w3id.org/gcdfo/salmon#hasDeme">has deme</a> <sup class="type-op" title="object property">op</sup>, <a href="#isAssessmentSubjectOf" title="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">is assessment subject of</a> <sup class="type-op" title="object property">op</sup>, <a href="#populationOf" title="https://w3id.org/gcdfo/salmon#populationOf">population of</a> <sup class="type-op" title="object property">op</sup>
    </dd>
    <dt>
     is in range of
    </dt>
    <dd>
-    <a href="#demeOf" title="https://w3id.org/gcdfo/salmon#demeOf">deme of</a> <sup class="type-op" title="object property">op</sup>, <a href="#hasPopulation" title="https://w3id.org/gcdfo/salmon#hasPopulation">has population</a> <sup class="type-op" title="object property">op</sup>
+    <a href="#demeOf" title="https://w3id.org/gcdfo/salmon#demeOf">deme of</a> <sup class="type-op" title="object property">op</sup>, <a href="#hasAssessmentSubject" title="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">has assessment subject</a> <sup class="type-op" title="object property">op</sup>, <a href="#hasPopulation" title="https://w3id.org/gcdfo/salmon#hasPopulation">has population</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -2017,6 +2059,18 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="#LimitReferencePoint" title="https://w3id.org/gcdfo/salmon#LimitReferencePoint">Limit reference point</a> <sup class="type-c" title="class">c</sup>, <a href="#UpperStockReferencePoint" title="https://w3id.org/gcdfo/salmon#UpperStockReferencePoint">Upper stock reference</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    is in domain of
+   </dt>
+   <dd>
+    <a href="#isAssessmentReferencePointFor" title="https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor">is assessment reference point for</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#hasAssessmentReferencePoint" title="https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint">has assessment reference point</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -2486,10 +2540,16 @@ This section provides details for each class and property defined by DFO Salmon 
     <a href="#ConservationUnit" title="https://w3id.org/gcdfo/salmon#ConservationUnit">Conservation Unit</a> <sup class="type-c" title="class">c</sup>, <a href="#IndicatorRiver" title="https://w3id.org/gcdfo/salmon#IndicatorRiver">Indicator river</a> <sup class="type-c" title="class">c</sup>, <a href="#Stock" title="https://w3id.org/gcdfo/salmon#Stock">Stock</a> <sup class="type-c" title="class">c</sup>, <a href="#StockManagementUnit" title="https://w3id.org/gcdfo/salmon#StockManagementUnit">Stock Management Unit</a> <sup class="type-c" title="class">c</sup>
    </dd>
    <dt>
+    is in domain of
+   </dt>
+   <dd>
+    <a href="#isAssessmentSubjectOf" title="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">is assessment subject of</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
     is in range of
    </dt>
    <dd>
-    <a href="#hasFeatureOfInterest" title="https://w3id.org/gcdfo/salmon#hasFeatureOfInterest">has feature of interest</a> <sup class="type-op" title="object property">op</sup>, <a href="#isSampleOfStratum" title="https://w3id.org/gcdfo/salmon#isSampleOfStratum">is sample of stratum</a> <sup class="type-op" title="object property">op</sup>
+    <a href="#hasAssessmentSubject" title="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">has assessment subject</a> <sup class="type-op" title="object property">op</sup>, <a href="#hasFeatureOfInterest" title="https://w3id.org/gcdfo/salmon#hasFeatureOfInterest">has feature of interest</a> <sup class="type-op" title="object property">op</sup>, <a href="#isSampleOfStratum" title="https://w3id.org/gcdfo/salmon#isSampleOfStratum">is sample of stratum</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -2789,6 +2849,18 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="#http://purl.obolibrary.org/obo/BFO_0000015" title="http://purl.obolibrary.org/obo/BFO_0000015">process</a> <sup class="type-c" title="class">c</sup>
    </dd>
+   <dt>
+    is in domain of
+   </dt>
+   <dd>
+    <a href="#hasAssessmentReferencePoint" title="https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint">has assessment reference point</a> <sup class="type-op" title="object property">op</sup>, <a href="#hasAssessmentSubject" title="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">has assessment subject</a> <sup class="type-op" title="object property">op</sup>, <a href="#usesAssessmentDatum" title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#isAssessmentReferencePointFor" title="https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor">is assessment reference point for</a> <sup class="type-op" title="object property">op</sup>, <a href="#isAssessmentSubjectOf" title="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">is assessment subject of</a> <sup class="type-op" title="object property">op</sup>, <a href="#isDatumUsedInAssessment" title="https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment">is datum used in assessment</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
   </dl>
  </div>
  <div class="entity" id="StockManagementUnit">
@@ -2987,6 +3059,12 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="#TargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate">Target or limit exploitation rate</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#usesAssessmentDatum" title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -3249,6 +3327,8 @@ This section provides details for each class and property defined by DFO Salmon 
  <ul class="hlist">
   <li><a href="#conservationUnitOf" title="https://w3id.org/gcdfo/salmon#conservationUnitOf">Conservation Unit of</a></li>
   <li><a href="#demeOf" title="https://w3id.org/gcdfo/salmon#demeOf">deme of</a></li>
+  <li><a href="#hasAssessmentReferencePoint" title="https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint">has assessment reference point</a></li>
+  <li><a href="#hasAssessmentSubject" title="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">has assessment subject</a></li>
   <li><a href="#hasConservationUnit" title="https://w3id.org/gcdfo/salmon#hasConservationUnit">has Conservation Unit</a></li>
   <li><a href="#hasDeme" title="https://w3id.org/gcdfo/salmon#hasDeme">has deme</a></li>
   <li><a href="#hasFeatureOfInterest" title="https://w3id.org/gcdfo/salmon#hasFeatureOfInterest">has feature of interest</a></li>
@@ -3258,10 +3338,14 @@ This section provides details for each class and property defined by DFO Salmon 
   <li><a href="#hasTargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">has target or limit exploitation rate</a></li>
   <li><a href="#hasYearBasis" title="https://w3id.org/gcdfo/salmon#hasYearBasis">has year basis</a></li>
   <li><a href="#http://www.w3.org/ns/dqv#inDimension" title="http://www.w3.org/ns/dqv#inDimension">in dimension</a></li>
+  <li><a href="#isAssessmentReferencePointFor" title="https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor">is assessment reference point for</a></li>
+  <li><a href="#isAssessmentSubjectOf" title="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">is assessment subject of</a></li>
+  <li><a href="#isDatumUsedInAssessment" title="https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment">is datum used in assessment</a></li>
   <li><a href="#isSampleOfStratum" title="https://w3id.org/gcdfo/salmon#isSampleOfStratum">is sample of stratum</a></li>
   <li><a href="#isTargetOrLimitForObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">is target or limit for observed exploitation rate</a></li>
   <li><a href="#populationOf" title="https://w3id.org/gcdfo/salmon#populationOf">population of</a></li>
   <li><a href="#usedProcedure" title="https://w3id.org/gcdfo/salmon#usedProcedure"> <span>used procedure</span> </a></li>
+  <li><a href="#usesAssessmentDatum" title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a></li>
   <li><a href="#usesObservationProcedure" title="https://w3id.org/gcdfo/salmon#usesObservationProcedure">uses observation procedure</a></li>
  </ul>
  <div class="entity" id="conservationUnitOf">
@@ -3334,6 +3418,86 @@ This section provides details for each class and property defined by DFO Salmon 
     </dt>
     <dd>
      <a href="#hasDeme" title="https://w3id.org/gcdfo/salmon#hasDeme">has deme</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
+ </div>
+ <div class="entity" id="hasAssessmentReferencePoint">
+  <h3>has assessment reference point<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint</p>
+  <div class="comment">
+   <span class="markdown">Relates a stock assessment process to a reference point used to interpret status or management risk.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has super-properties
+    </dt>
+    <dd>
+     <a href="http://www.w3.org/ns/prov#used" target="_blank" title="http://www.w3.org/ns/prov#used">used</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#StockAssessment" title="https://w3id.org/gcdfo/salmon#StockAssessment">Stock assessment</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#ReferencePoint" title="https://w3id.org/gcdfo/salmon#ReferencePoint">Reference point</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#isAssessmentReferencePointFor" title="https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor">is assessment reference point for</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
+ </div>
+ <div class="entity" id="hasAssessmentSubject">
+  <h3>has assessment subject<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#hasAssessmentSubject</p>
+  <div class="comment">
+   <span class="markdown">Relates a stock-assessment process to the reporting/management stratum or biological population it evaluates.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#StockAssessment" title="https://w3id.org/gcdfo/salmon#StockAssessment">Stock assessment</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#Population" title="https://w3id.org/gcdfo/salmon#Population">Population</a> <sup class="type-c" title="class">c</sup> <span class="logic">or</span> <a href="#ReportingOrManagementStratum" title="https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum">Reporting or management stratum</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#isAssessmentSubjectOf" title="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">is assessment subject of</a> <sup class="type-op" title="object property">op</sup>
     </dd>
    </dl>
   </div>
@@ -3657,6 +3821,117 @@ This section provides details for each class and property defined by DFO Salmon 
    </dd>
   </dl>
  </div>
+ <div class="entity" id="isAssessmentReferencePointFor">
+  <h3>is assessment reference point for<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor</p>
+  <div class="comment">
+   <span class="markdown">Relates a reference point to a stock assessment process that uses it for status interpretation or advice.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#ReferencePoint" title="https://w3id.org/gcdfo/salmon#ReferencePoint">Reference point</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#StockAssessment" title="https://w3id.org/gcdfo/salmon#StockAssessment">Stock assessment</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#hasAssessmentReferencePoint" title="https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint">has assessment reference point</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
+ </div>
+ <div class="entity" id="isAssessmentSubjectOf">
+  <h3>is assessment subject of<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf</p>
+  <div class="comment">
+   <span class="markdown">Relates a reporting/management stratum or biological population to a stock assessment that evaluates it.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#Population" title="https://w3id.org/gcdfo/salmon#Population">Population</a> <sup class="type-c" title="class">c</sup> <span class="logic">or</span> <a href="#ReportingOrManagementStratum" title="https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum">Reporting or management stratum</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#StockAssessment" title="https://w3id.org/gcdfo/salmon#StockAssessment">Stock assessment</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#hasAssessmentSubject" title="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">has assessment subject</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
+ </div>
+ <div class="entity" id="isDatumUsedInAssessment">
+  <h3>is datum used in assessment<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment</p>
+  <div class="comment">
+   <span class="markdown">Relates a measurement datum to a stock assessment process that uses it as evidence.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#http://purl.obolibrary.org/obo/IAO_0000109" title="http://purl.obolibrary.org/obo/IAO_0000109">measurement datum</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#StockAssessment" title="https://w3id.org/gcdfo/salmon#StockAssessment">Stock assessment</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#usesAssessmentDatum" title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
+ </div>
  <div class="entity" id="isSampleOfStratum">
   <h3>is sample of stratum<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#isSampleOfStratum</p>
@@ -3784,6 +4059,52 @@ This section provides details for each class and property defined by DFO Salmon 
     </dt>
     <dd>
      annotation property
+    </dd>
+   </dl>
+  </div>
+ </div>
+ <div class="entity" id="usesAssessmentDatum">
+  <h3>uses assessment datum<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#usesAssessmentDatum</p>
+  <div class="comment">
+   <span class="markdown">Relates a stock assessment to a measurement datum used as assessment input or evidence.</span>
+  </div>
+  <div class="comment">
+   <span class="markdown">Range explicitly includes measurement datum plus common rate classes used in stock-assessment workflows.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has super-properties
+    </dt>
+    <dd>
+     <a href="http://www.w3.org/ns/prov#used" target="_blank" title="http://www.w3.org/ns/prov#used">used</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#StockAssessment" title="https://w3id.org/gcdfo/salmon#StockAssessment">Stock assessment</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#http://purl.obolibrary.org/obo/IAO_0000109" title="http://purl.obolibrary.org/obo/IAO_0000109">measurement datum</a> <sup class="type-c" title="class">c</sup> <span class="logic">or</span> <a href="#ObservedRateOrAbundance" title="https://w3id.org/gcdfo/salmon#ObservedRateOrAbundance">Observed rate or abundance</a> <sup class="type-c" title="class">c</sup> <span class="logic">or</span> <a href="#TargetOrLimitRateOrAbundance" title="https://w3id.org/gcdfo/salmon#TargetOrLimitRateOrAbundance">Target or limit rate or abundance</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#isDatumUsedInAssessment" title="https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment">is datum used in assessment</a> <sup class="type-op" title="object property">op</sup>
     </dd>
    </dl>
   </div>
@@ -4240,6 +4561,21 @@ This section provides details for each class and property defined by DFO Salmon 
 <li>Added: domain https://w3id.org/gcdfo/salmon#Deme</li>
 </ul>
 </li>
+<li><a href="#hasAssessmentReferencePoint">https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint&gt; &lt;https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor&gt;)</li>
+<li>Added: Range https://w3id.org/gcdfo/salmon#ReferencePoint</li>
+<li>Added: SubProperty of http://www.w3.org/ns/prov#used</li>
+<li>Added: domain https://w3id.org/gcdfo/salmon#StockAssessment</li>
+</ul>
+</li>
+<li><a href="#hasAssessmentSubject">https://w3id.org/gcdfo/salmon#hasAssessmentSubject</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#hasAssessmentSubject&gt; &lt;https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf&gt;)</li>
+<li>Added: Range Union of (https://w3id.org/gcdfo/salmon#Population, https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum)</li>
+<li>Added: domain https://w3id.org/gcdfo/salmon#StockAssessment</li>
+</ul>
+</li>
 <li><a href="#hasConservationUnit">https://w3id.org/gcdfo/salmon#hasConservationUnit</a>
 <ul>
 <li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#conservationUnitOf&gt; &lt;https://w3id.org/gcdfo/salmon#hasConservationUnit&gt;)</li>
@@ -4297,6 +4633,27 @@ This section provides details for each class and property defined by DFO Salmon 
 <li>Added: domain Union of (https://w3id.org/gcdfo/salmon#EscapementMeasurement, https://w3id.org/gcdfo/salmon#ExploitationRate, https://w3id.org/gcdfo/salmon#ObservedExploitationRate, https://w3id.org/gcdfo/salmon#SpawnerAbundance, https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate, https://w3id.org/gcdfo/salmon#TotalExploitationRate)</li>
 </ul>
 </li>
+<li><a href="#isAssessmentReferencePointFor">https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint&gt; &lt;https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor&gt;)</li>
+<li>Added: Range https://w3id.org/gcdfo/salmon#StockAssessment</li>
+<li>Added: domain https://w3id.org/gcdfo/salmon#ReferencePoint</li>
+</ul>
+</li>
+<li><a href="#isAssessmentSubjectOf">https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#hasAssessmentSubject&gt; &lt;https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf&gt;)</li>
+<li>Added: Range https://w3id.org/gcdfo/salmon#StockAssessment</li>
+<li>Added: domain Union of (https://w3id.org/gcdfo/salmon#Population, https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum)</li>
+</ul>
+</li>
+<li><a href="#isDatumUsedInAssessment">https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment&gt; &lt;https://w3id.org/gcdfo/salmon#usesAssessmentDatum&gt;)</li>
+<li>Added: Range https://w3id.org/gcdfo/salmon#StockAssessment</li>
+<li>Added: domain http://purl.obolibrary.org/obo/IAO_0000109</li>
+</ul>
+</li>
 <li><a href="#isSampleOfStratum">https://w3id.org/gcdfo/salmon#isSampleOfStratum</a>
 <ul>
 <li>Added: Range https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum</li>
@@ -4322,6 +4679,14 @@ This section provides details for each class and property defined by DFO Salmon 
 <li><a href="#usedProcedure">https://w3id.org/gcdfo/salmon#usedProcedure</a>
 <ul>
 <li>Added: SubProperty of http://www.w3.org/ns/sosa/usedProcedure</li>
+</ul>
+</li>
+<li><a href="#usesAssessmentDatum">https://w3id.org/gcdfo/salmon#usesAssessmentDatum</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment&gt; &lt;https://w3id.org/gcdfo/salmon#usesAssessmentDatum&gt;)</li>
+<li>Added: Range Union of (http://purl.obolibrary.org/obo/IAO_0000109, https://w3id.org/gcdfo/salmon#ObservedRateOrAbundance, https://w3id.org/gcdfo/salmon#TargetOrLimitRateOrAbundance)</li>
+<li>Added: SubProperty of http://www.w3.org/ns/prov#used</li>
+<li>Added: domain https://w3id.org/gcdfo/salmon#StockAssessment</li>
 </ul>
 </li>
 <li><a href="#usesObservationProcedure">https://w3id.org/gcdfo/salmon#usesObservationProcedure</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"https://w3id.org/gcdfo/salmon","image":"http://vowl.visualdataweb.org/webvowl/#iri=https://w3id.org/gcdfo/salmon#","name":"DFO Salmon Ontology","headline":"Document describing the ontology https://w3id.org/gcdfo/salmon#","dateReleased":"2025-09-06","dateModified":"2026-02-24","version":"0.0.6-alpha (integrated pre-release review branch)","license":"https://creativecommons.org/licenses/by/4.0/","codeRepository":"https://github.com/dfo-pacific-science/dfo-salmon-ontology","author":[{"@type":"Person","name":"Fishery & Assessment Data Section (FADS) Data Stewardship Unit"}],"contributor":[{"@type":"Person","name":"Brett Johnson"},{"@type":"Person","name":"Melissa K. Morrison"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"https://w3id.org/gcdfo/salmon","image":"http://vowl.visualdataweb.org/webvowl/#iri=https://w3id.org/gcdfo/salmon#","name":"DFO Salmon Ontology","headline":"Document describing the ontology https://w3id.org/gcdfo/salmon#","dateReleased":"2025-09-06","dateModified":"2026-03-02","version":"0.0.6-alpha (integrated pre-release review branch)","license":"https://creativecommons.org/licenses/by/4.0/","codeRepository":"https://github.com/dfo-pacific-science/dfo-salmon-ontology","author":[{"@type":"Person","name":"Fishery & Assessment Data Section (FADS) Data Stewardship Unit"}],"contributor":[{"@type":"Person","name":"Brett Johnson"},{"@type":"Person","name":"Melissa K. Morrison"}]}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -540,11 +540,11 @@ $(function(){
 <div class="head">
 <div style="float:right">language <a href="index-en.html"><b>en</b></a> </div>
 <h1>DFO Salmon Ontology</h1>
-<h2>Release: 2026-02-24</h2>
+<h2>Release: 2026-03-02</h2>
 
 
 <dl>
-<dt>Modified on: 2026-02-24</dt>
+<dt>Modified on: 2026-03-02</dt>
 <dt>This version:</dt>
 <dd><a href="https://w3id.org/gcdfo/salmon/0.0.6-alpha">https://w3id.org/gcdfo/salmon/0.0.6-alpha</a></dd>
 <dt>Latest version:</dt>
@@ -868,7 +868,7 @@ This ontology has the following classes and properties.</span>
    <li>
       <a href="#http://purl.dataone.org/odo/ECSO_00002050" title="http://purl.dataone.org/odo/ECSO_00002050">year of measurement</a>
    </li>
-</ul></details><h4>Object Properties</h4><details class="gcdfo-collapsible gcdfo-overview-collapsible" open><summary>16 items (expand)</summary><ul xmlns:widoco="https://w3id.org/widoco/vocab#"
+</ul></details><h4>Object Properties</h4><details class="gcdfo-collapsible gcdfo-overview-collapsible" open><summary>22 items (expand)</summary><ul xmlns:widoco="https://w3id.org/widoco/vocab#"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     class="hlist">
    <li>
@@ -876,6 +876,14 @@ This ontology has the following classes and properties.</span>
    </li>
    <li>
       <a href="#demeOf" title="https://w3id.org/gcdfo/salmon#demeOf">deme of</a>
+   </li>
+   <li>
+      <a href="#hasAssessmentReferencePoint"
+         title="https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint">has assessment reference point</a>
+   </li>
+   <li>
+      <a href="#hasAssessmentSubject"
+         title="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">has assessment subject</a>
    </li>
    <li>
       <a href="#hasConservationUnit"
@@ -910,6 +918,18 @@ This ontology has the following classes and properties.</span>
       <a href="#http://www.w3.org/ns/dqv#inDimension" title="http://www.w3.org/ns/dqv#inDimension">in dimension</a>
    </li>
    <li>
+      <a href="#isAssessmentReferencePointFor"
+         title="https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor">is assessment reference point for</a>
+   </li>
+   <li>
+      <a href="#isAssessmentSubjectOf"
+         title="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">is assessment subject of</a>
+   </li>
+   <li>
+      <a href="#isDatumUsedInAssessment"
+         title="https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment">is datum used in assessment</a>
+   </li>
+   <li>
       <a href="#isSampleOfStratum" title="https://w3id.org/gcdfo/salmon#isSampleOfStratum">is sample of stratum</a>
    </li>
    <li>
@@ -923,6 +943,10 @@ This ontology has the following classes and properties.</span>
       <a href="#usedProcedure" title="https://w3id.org/gcdfo/salmon#usedProcedure">
          <span>used procedure</span>
       </a>
+   </li>
+   <li>
+      <a href="#usesAssessmentDatum"
+         title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a>
    </li>
    <li>
       <a href="#usesObservationProcedure"
@@ -4490,6 +4514,18 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="#EscapementMeasurement" title="https://w3id.org/gcdfo/salmon#EscapementMeasurement">Escapement measurement</a> <sup class="type-c" title="class">c</sup>, <a href="#ExploitationRate" title="https://w3id.org/gcdfo/salmon#ExploitationRate">Exploitation rate</a> <sup class="type-c" title="class">c</sup>, <a href="#ObservedRateOrAbundance" title="https://w3id.org/gcdfo/salmon#ObservedRateOrAbundance">Observed rate or abundance</a> <sup class="type-c" title="class">c</sup>, <a href="#http://purl.dataone.org/odo/SALMON_00000479" title="http://purl.dataone.org/odo/SALMON_00000479">Salmon escapement count</a> <sup class="type-c" title="class">c</sup>, <a href="#TargetOrLimitRateOrAbundance" title="https://w3id.org/gcdfo/salmon#TargetOrLimitRateOrAbundance">Target or limit rate or abundance</a> <sup class="type-c" title="class">c</sup>, <a href="#http://purl.dataone.org/odo/ECSO_00002050" title="http://purl.dataone.org/odo/ECSO_00002050">year of measurement</a> <sup class="type-c" title="class">c</sup>
    </dd>
+   <dt>
+    is in domain of
+   </dt>
+   <dd>
+    <a href="#isDatumUsedInAssessment" title="https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment">is datum used in assessment</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#usesAssessmentDatum" title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
   </dl>
  </div>
  <div class="entity" id="MetricBenchmark">
@@ -4610,6 +4646,12 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="#CWTMarineSurvivalRate" title="https://w3id.org/gcdfo/salmon#CWTMarineSurvivalRate">CWT marine survival rate</a> <sup class="type-c" title="class">c</sup>, <a href="#InRiverMortalityRate" title="https://w3id.org/gcdfo/salmon#InRiverMortalityRate">In-river mortality rate</a> <sup class="type-c" title="class">c</sup>, <a href="#MainstemMortalityRate" title="https://w3id.org/gcdfo/salmon#MainstemMortalityRate">Mainstem mortality rate</a> <sup class="type-c" title="class">c</sup>, <a href="#MarineSurvivalIndex" title="https://w3id.org/gcdfo/salmon#MarineSurvivalIndex">Marine survival index</a> <sup class="type-c" title="class">c</sup>, <a href="#ObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#ObservedExploitationRate">Observed exploitation rate</a> <sup class="type-c" title="class">c</sup>, <a href="#OceanMortalityRate" title="https://w3id.org/gcdfo/salmon#OceanMortalityRate">Ocean mortality rate</a> <sup class="type-c" title="class">c</sup>, <a href="#ProportionHatcheryOriginSpawners" title="https://w3id.org/gcdfo/salmon#ProportionHatcheryOriginSpawners">Proportion of hatchery-origin spawners</a> <sup class="type-c" title="class">c</sup>, <a href="#SpawnerAbundance" title="https://w3id.org/gcdfo/salmon#SpawnerAbundance">Spawner abundance</a> <sup class="type-c" title="class">c</sup>, <a href="#SpawnerAbundanceChange" title="https://w3id.org/gcdfo/salmon#SpawnerAbundanceChange">Spawner abundance change</a> <sup class="type-c" title="class">c</sup>, <a href="#SpawnerAbundancePercentile" title="https://w3id.org/gcdfo/salmon#SpawnerAbundancePercentile">Spawner abundance percentile</a> <sup class="type-c" title="class">c</sup>, <a href="#SpawnerAbundanceTrend" title="https://w3id.org/gcdfo/salmon#SpawnerAbundanceTrend">Spawner abundance trend</a> <sup class="type-c" title="class">c</sup>, <a href="#TerminalMortalityRate" title="https://w3id.org/gcdfo/salmon#TerminalMortalityRate">Terminal mortality rate</a> <sup class="type-c" title="class">c</sup>, <a href="#TotalMortalityRate" title="https://w3id.org/gcdfo/salmon#TotalMortalityRate">Total mortality rate</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#usesAssessmentDatum" title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -4792,13 +4834,13 @@ This section provides details for each class and property defined by DFO Salmon 
     is in domain of
    </dt>
    <dd>
-    <a href="#hasDeme" title="https://w3id.org/gcdfo/salmon#hasDeme">has deme</a> <sup class="type-op" title="object property">op</sup>, <a href="#populationOf" title="https://w3id.org/gcdfo/salmon#populationOf">population of</a> <sup class="type-op" title="object property">op</sup>
+    <a href="#hasDeme" title="https://w3id.org/gcdfo/salmon#hasDeme">has deme</a> <sup class="type-op" title="object property">op</sup>, <a href="#isAssessmentSubjectOf" title="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">is assessment subject of</a> <sup class="type-op" title="object property">op</sup>, <a href="#populationOf" title="https://w3id.org/gcdfo/salmon#populationOf">population of</a> <sup class="type-op" title="object property">op</sup>
    </dd>
    <dt>
     is in range of
    </dt>
    <dd>
-    <a href="#demeOf" title="https://w3id.org/gcdfo/salmon#demeOf">deme of</a> <sup class="type-op" title="object property">op</sup>, <a href="#hasPopulation" title="https://w3id.org/gcdfo/salmon#hasPopulation">has population</a> <sup class="type-op" title="object property">op</sup>
+    <a href="#demeOf" title="https://w3id.org/gcdfo/salmon#demeOf">deme of</a> <sup class="type-op" title="object property">op</sup>, <a href="#hasAssessmentSubject" title="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">has assessment subject</a> <sup class="type-op" title="object property">op</sup>, <a href="#hasPopulation" title="https://w3id.org/gcdfo/salmon#hasPopulation">has population</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -4961,6 +5003,18 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="#LimitReferencePoint" title="https://w3id.org/gcdfo/salmon#LimitReferencePoint">Limit reference point</a> <sup class="type-c" title="class">c</sup>, <a href="#UpperStockReferencePoint" title="https://w3id.org/gcdfo/salmon#UpperStockReferencePoint">Upper stock reference</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    is in domain of
+   </dt>
+   <dd>
+    <a href="#isAssessmentReferencePointFor" title="https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor">is assessment reference point for</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#hasAssessmentReferencePoint" title="https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint">has assessment reference point</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -5430,10 +5484,16 @@ This section provides details for each class and property defined by DFO Salmon 
     <a href="#ConservationUnit" title="https://w3id.org/gcdfo/salmon#ConservationUnit">Conservation Unit</a> <sup class="type-c" title="class">c</sup>, <a href="#IndicatorRiver" title="https://w3id.org/gcdfo/salmon#IndicatorRiver">Indicator river</a> <sup class="type-c" title="class">c</sup>, <a href="#Stock" title="https://w3id.org/gcdfo/salmon#Stock">Stock</a> <sup class="type-c" title="class">c</sup>, <a href="#StockManagementUnit" title="https://w3id.org/gcdfo/salmon#StockManagementUnit">Stock Management Unit</a> <sup class="type-c" title="class">c</sup>
    </dd>
    <dt>
+    is in domain of
+   </dt>
+   <dd>
+    <a href="#isAssessmentSubjectOf" title="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">is assessment subject of</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
     is in range of
    </dt>
    <dd>
-    <a href="#hasFeatureOfInterest" title="https://w3id.org/gcdfo/salmon#hasFeatureOfInterest">has feature of interest</a> <sup class="type-op" title="object property">op</sup>, <a href="#isSampleOfStratum" title="https://w3id.org/gcdfo/salmon#isSampleOfStratum">is sample of stratum</a> <sup class="type-op" title="object property">op</sup>
+    <a href="#hasAssessmentSubject" title="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">has assessment subject</a> <sup class="type-op" title="object property">op</sup>, <a href="#hasFeatureOfInterest" title="https://w3id.org/gcdfo/salmon#hasFeatureOfInterest">has feature of interest</a> <sup class="type-op" title="object property">op</sup>, <a href="#isSampleOfStratum" title="https://w3id.org/gcdfo/salmon#isSampleOfStratum">is sample of stratum</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -5733,6 +5793,18 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="#http://purl.obolibrary.org/obo/BFO_0000015" title="http://purl.obolibrary.org/obo/BFO_0000015">process</a> <sup class="type-c" title="class">c</sup>
    </dd>
+   <dt>
+    is in domain of
+   </dt>
+   <dd>
+    <a href="#hasAssessmentReferencePoint" title="https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint">has assessment reference point</a> <sup class="type-op" title="object property">op</sup>, <a href="#hasAssessmentSubject" title="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">has assessment subject</a> <sup class="type-op" title="object property">op</sup>, <a href="#usesAssessmentDatum" title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#isAssessmentReferencePointFor" title="https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor">is assessment reference point for</a> <sup class="type-op" title="object property">op</sup>, <a href="#isAssessmentSubjectOf" title="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">is assessment subject of</a> <sup class="type-op" title="object property">op</sup>, <a href="#isDatumUsedInAssessment" title="https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment">is datum used in assessment</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
   </dl>
  </div>
  <div class="entity" id="StockManagementUnit">
@@ -5931,6 +6003,12 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="#TargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate">Target or limit exploitation rate</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    is in range of
+   </dt>
+   <dd>
+    <a href="#usesAssessmentDatum" title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -6193,6 +6271,8 @@ This section provides details for each class and property defined by DFO Salmon 
  <ul class="hlist">
   <li><a href="#conservationUnitOf" title="https://w3id.org/gcdfo/salmon#conservationUnitOf">Conservation Unit of</a></li>
   <li><a href="#demeOf" title="https://w3id.org/gcdfo/salmon#demeOf">deme of</a></li>
+  <li><a href="#hasAssessmentReferencePoint" title="https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint">has assessment reference point</a></li>
+  <li><a href="#hasAssessmentSubject" title="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">has assessment subject</a></li>
   <li><a href="#hasConservationUnit" title="https://w3id.org/gcdfo/salmon#hasConservationUnit">has Conservation Unit</a></li>
   <li><a href="#hasDeme" title="https://w3id.org/gcdfo/salmon#hasDeme">has deme</a></li>
   <li><a href="#hasFeatureOfInterest" title="https://w3id.org/gcdfo/salmon#hasFeatureOfInterest">has feature of interest</a></li>
@@ -6202,10 +6282,14 @@ This section provides details for each class and property defined by DFO Salmon 
   <li><a href="#hasTargetOrLimitExploitationRate" title="https://w3id.org/gcdfo/salmon#hasTargetOrLimitExploitationRate">has target or limit exploitation rate</a></li>
   <li><a href="#hasYearBasis" title="https://w3id.org/gcdfo/salmon#hasYearBasis">has year basis</a></li>
   <li><a href="#http://www.w3.org/ns/dqv#inDimension" title="http://www.w3.org/ns/dqv#inDimension">in dimension</a></li>
+  <li><a href="#isAssessmentReferencePointFor" title="https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor">is assessment reference point for</a></li>
+  <li><a href="#isAssessmentSubjectOf" title="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">is assessment subject of</a></li>
+  <li><a href="#isDatumUsedInAssessment" title="https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment">is datum used in assessment</a></li>
   <li><a href="#isSampleOfStratum" title="https://w3id.org/gcdfo/salmon#isSampleOfStratum">is sample of stratum</a></li>
   <li><a href="#isTargetOrLimitForObservedExploitationRate" title="https://w3id.org/gcdfo/salmon#isTargetOrLimitForObservedExploitationRate">is target or limit for observed exploitation rate</a></li>
   <li><a href="#populationOf" title="https://w3id.org/gcdfo/salmon#populationOf">population of</a></li>
   <li><a href="#usedProcedure" title="https://w3id.org/gcdfo/salmon#usedProcedure"> <span>used procedure</span> </a></li>
+  <li><a href="#usesAssessmentDatum" title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a></li>
   <li><a href="#usesObservationProcedure" title="https://w3id.org/gcdfo/salmon#usesObservationProcedure">uses observation procedure</a></li>
  </ul>
  <div class="entity" id="conservationUnitOf">
@@ -6278,6 +6362,86 @@ This section provides details for each class and property defined by DFO Salmon 
     </dt>
     <dd>
      <a href="#hasDeme" title="https://w3id.org/gcdfo/salmon#hasDeme">has deme</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
+ </div>
+ <div class="entity" id="hasAssessmentReferencePoint">
+  <h3>has assessment reference point<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint</p>
+  <div class="comment">
+   <span class="markdown">Relates a stock assessment process to a reference point used to interpret status or management risk.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has super-properties
+    </dt>
+    <dd>
+     <a href="http://www.w3.org/ns/prov#used" target="_blank" title="http://www.w3.org/ns/prov#used">used</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#StockAssessment" title="https://w3id.org/gcdfo/salmon#StockAssessment">Stock assessment</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#ReferencePoint" title="https://w3id.org/gcdfo/salmon#ReferencePoint">Reference point</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#isAssessmentReferencePointFor" title="https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor">is assessment reference point for</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
+ </div>
+ <div class="entity" id="hasAssessmentSubject">
+  <h3>has assessment subject<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#hasAssessmentSubject</p>
+  <div class="comment">
+   <span class="markdown">Relates a stock-assessment process to the reporting/management stratum or biological population it evaluates.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#StockAssessment" title="https://w3id.org/gcdfo/salmon#StockAssessment">Stock assessment</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#Population" title="https://w3id.org/gcdfo/salmon#Population">Population</a> <sup class="type-c" title="class">c</sup> <span class="logic">or</span> <a href="#ReportingOrManagementStratum" title="https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum">Reporting or management stratum</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#isAssessmentSubjectOf" title="https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf">is assessment subject of</a> <sup class="type-op" title="object property">op</sup>
     </dd>
    </dl>
   </div>
@@ -6601,6 +6765,117 @@ This section provides details for each class and property defined by DFO Salmon 
    </dd>
   </dl>
  </div>
+ <div class="entity" id="isAssessmentReferencePointFor">
+  <h3>is assessment reference point for<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor</p>
+  <div class="comment">
+   <span class="markdown">Relates a reference point to a stock assessment process that uses it for status interpretation or advice.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#ReferencePoint" title="https://w3id.org/gcdfo/salmon#ReferencePoint">Reference point</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#StockAssessment" title="https://w3id.org/gcdfo/salmon#StockAssessment">Stock assessment</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#hasAssessmentReferencePoint" title="https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint">has assessment reference point</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
+ </div>
+ <div class="entity" id="isAssessmentSubjectOf">
+  <h3>is assessment subject of<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf</p>
+  <div class="comment">
+   <span class="markdown">Relates a reporting/management stratum or biological population to a stock assessment that evaluates it.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#Population" title="https://w3id.org/gcdfo/salmon#Population">Population</a> <sup class="type-c" title="class">c</sup> <span class="logic">or</span> <a href="#ReportingOrManagementStratum" title="https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum">Reporting or management stratum</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#StockAssessment" title="https://w3id.org/gcdfo/salmon#StockAssessment">Stock assessment</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#hasAssessmentSubject" title="https://w3id.org/gcdfo/salmon#hasAssessmentSubject">has assessment subject</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
+ </div>
+ <div class="entity" id="isDatumUsedInAssessment">
+  <h3>is datum used in assessment<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment</p>
+  <div class="comment">
+   <span class="markdown">Relates a measurement datum to a stock assessment process that uses it as evidence.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#http://purl.obolibrary.org/obo/IAO_0000109" title="http://purl.obolibrary.org/obo/IAO_0000109">measurement datum</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#StockAssessment" title="https://w3id.org/gcdfo/salmon#StockAssessment">Stock assessment</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#usesAssessmentDatum" title="https://w3id.org/gcdfo/salmon#usesAssessmentDatum">uses assessment datum</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+   </dl>
+  </div>
+ </div>
  <div class="entity" id="isSampleOfStratum">
   <h3>is sample of stratum<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#isSampleOfStratum</p>
@@ -6728,6 +7003,52 @@ This section provides details for each class and property defined by DFO Salmon 
     </dt>
     <dd>
      annotation property
+    </dd>
+   </dl>
+  </div>
+ </div>
+ <div class="entity" id="usesAssessmentDatum">
+  <h3>uses assessment datum<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#usesAssessmentDatum</p>
+  <div class="comment">
+   <span class="markdown">Relates a stock assessment to a measurement datum used as assessment input or evidence.</span>
+  </div>
+  <div class="comment">
+   <span class="markdown">Range explicitly includes measurement datum plus common rate classes used in stock-assessment workflows.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <div class="description">
+   <dl>
+    <dt>
+     has super-properties
+    </dt>
+    <dd>
+     <a href="http://www.w3.org/ns/prov#used" target="_blank" title="http://www.w3.org/ns/prov#used">used</a> <sup class="type-op" title="object property">op</sup>
+    </dd>
+    <dt>
+     has domain
+    </dt>
+    <dd>
+     <a href="#StockAssessment" title="https://w3id.org/gcdfo/salmon#StockAssessment">Stock assessment</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     has range
+    </dt>
+    <dd>
+     <a href="#http://purl.obolibrary.org/obo/IAO_0000109" title="http://purl.obolibrary.org/obo/IAO_0000109">measurement datum</a> <sup class="type-c" title="class">c</sup> <span class="logic">or</span> <a href="#ObservedRateOrAbundance" title="https://w3id.org/gcdfo/salmon#ObservedRateOrAbundance">Observed rate or abundance</a> <sup class="type-c" title="class">c</sup> <span class="logic">or</span> <a href="#TargetOrLimitRateOrAbundance" title="https://w3id.org/gcdfo/salmon#TargetOrLimitRateOrAbundance">Target or limit rate or abundance</a> <sup class="type-c" title="class">c</sup>
+    </dd>
+    <dt>
+     is inverse of
+    </dt>
+    <dd>
+     <a href="#isDatumUsedInAssessment" title="https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment">is datum used in assessment</a> <sup class="type-op" title="object property">op</sup>
     </dd>
    </dl>
   </div>
@@ -7184,6 +7505,21 @@ This section provides details for each class and property defined by DFO Salmon 
 <li>Added: domain https://w3id.org/gcdfo/salmon#Deme</li>
 </ul>
 </li>
+<li><a href="#hasAssessmentReferencePoint">https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint&gt; &lt;https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor&gt;)</li>
+<li>Added: Range https://w3id.org/gcdfo/salmon#ReferencePoint</li>
+<li>Added: SubProperty of http://www.w3.org/ns/prov#used</li>
+<li>Added: domain https://w3id.org/gcdfo/salmon#StockAssessment</li>
+</ul>
+</li>
+<li><a href="#hasAssessmentSubject">https://w3id.org/gcdfo/salmon#hasAssessmentSubject</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#hasAssessmentSubject&gt; &lt;https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf&gt;)</li>
+<li>Added: Range Union of (https://w3id.org/gcdfo/salmon#Population, https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum)</li>
+<li>Added: domain https://w3id.org/gcdfo/salmon#StockAssessment</li>
+</ul>
+</li>
 <li><a href="#hasConservationUnit">https://w3id.org/gcdfo/salmon#hasConservationUnit</a>
 <ul>
 <li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#conservationUnitOf&gt; &lt;https://w3id.org/gcdfo/salmon#hasConservationUnit&gt;)</li>
@@ -7241,6 +7577,27 @@ This section provides details for each class and property defined by DFO Salmon 
 <li>Added: domain Union of (https://w3id.org/gcdfo/salmon#EscapementMeasurement, https://w3id.org/gcdfo/salmon#ExploitationRate, https://w3id.org/gcdfo/salmon#ObservedExploitationRate, https://w3id.org/gcdfo/salmon#SpawnerAbundance, https://w3id.org/gcdfo/salmon#TargetOrLimitExploitationRate, https://w3id.org/gcdfo/salmon#TotalExploitationRate)</li>
 </ul>
 </li>
+<li><a href="#isAssessmentReferencePointFor">https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint&gt; &lt;https://w3id.org/gcdfo/salmon#isAssessmentReferencePointFor&gt;)</li>
+<li>Added: Range https://w3id.org/gcdfo/salmon#StockAssessment</li>
+<li>Added: domain https://w3id.org/gcdfo/salmon#ReferencePoint</li>
+</ul>
+</li>
+<li><a href="#isAssessmentSubjectOf">https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#hasAssessmentSubject&gt; &lt;https://w3id.org/gcdfo/salmon#isAssessmentSubjectOf&gt;)</li>
+<li>Added: Range https://w3id.org/gcdfo/salmon#StockAssessment</li>
+<li>Added: domain Union of (https://w3id.org/gcdfo/salmon#Population, https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum)</li>
+</ul>
+</li>
+<li><a href="#isDatumUsedInAssessment">https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment&gt; &lt;https://w3id.org/gcdfo/salmon#usesAssessmentDatum&gt;)</li>
+<li>Added: Range https://w3id.org/gcdfo/salmon#StockAssessment</li>
+<li>Added: domain http://purl.obolibrary.org/obo/IAO_0000109</li>
+</ul>
+</li>
 <li><a href="#isSampleOfStratum">https://w3id.org/gcdfo/salmon#isSampleOfStratum</a>
 <ul>
 <li>Added: Range https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum</li>
@@ -7266,6 +7623,14 @@ This section provides details for each class and property defined by DFO Salmon 
 <li><a href="#usedProcedure">https://w3id.org/gcdfo/salmon#usedProcedure</a>
 <ul>
 <li>Added: SubProperty of http://www.w3.org/ns/sosa/usedProcedure</li>
+</ul>
+</li>
+<li><a href="#usesAssessmentDatum">https://w3id.org/gcdfo/salmon#usesAssessmentDatum</a>
+<ul>
+<li>Added: InverseObjectProperties InverseObjectProperties(&lt;https://w3id.org/gcdfo/salmon#isDatumUsedInAssessment&gt; &lt;https://w3id.org/gcdfo/salmon#usesAssessmentDatum&gt;)</li>
+<li>Added: Range Union of (http://purl.obolibrary.org/obo/IAO_0000109, https://w3id.org/gcdfo/salmon#ObservedRateOrAbundance, https://w3id.org/gcdfo/salmon#TargetOrLimitRateOrAbundance)</li>
+<li>Added: SubProperty of http://www.w3.org/ns/prov#used</li>
+<li>Added: domain https://w3id.org/gcdfo/salmon#StockAssessment</li>
 </ul>
 </li>
 <li><a href="#usesObservationProcedure">https://w3id.org/gcdfo/salmon#usesObservationProcedure</a>

--- a/ontology/dfo-salmon.ttl
+++ b/ontology/dfo-salmon.ttl
@@ -178,7 +178,7 @@ xsd:anyURI   a rdfs:Datatype .
   vann:preferredNamespaceUri "https://w3id.org/gcdfo/salmon#" ;
   vann:preferredNamespacePrefix "gcdfo" ;
   dcterms:created "2025-09-06"^^xsd:date ;
-  dcterms:modified "2026-02-24"^^xsd:date ;
+  dcterms:modified "2026-03-02"^^xsd:date ;
   dcterms:description "OWL + SKOS ontology for DFO salmon data: stocks/CUs/MUs, survey events, escapement measurements, and GSI constructs; aligns to DwC via rdfs:subClassOf; hybrid approach with SKOS for methods and OWL for events."@en ;
   schema:codeRepository <https://github.com/dfo-pacific-science/dfo-salmon-ontology> ;
   rdfs:seeAlso <https://github.com/dfo-pacific-science/dfo-salmon-ontology> ;
@@ -1519,6 +1519,67 @@ gcdfo:hasObservedVariable a owl:ObjectProperty ;
   rdfs:subPropertyOf sosa:observedProperty ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:DataModelProvenanceTheme .
+
+#################################################################
+# Object Properties — Process bridge to assessment/management graph
+#################################################################
+
+gcdfo:hasAssessmentSubject a owl:ObjectProperty ;
+  rdfs:label "has assessment subject"@en ;
+  iao:0000115 "Relates a stock-assessment process to the reporting/management stratum or biological population it evaluates."@en ; # definition
+  rdfs:domain gcdfo:StockAssessment ;
+  rdfs:range [ owl:unionOf ( gcdfo:ReportingOrManagementStratum gcdfo:Population ) ] ;
+  owl:inverseOf gcdfo:isAssessmentSubjectOf ;
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:PolicyGovernanceTheme, gcdfo:DataModelProvenanceTheme .
+
+gcdfo:isAssessmentSubjectOf a owl:ObjectProperty ;
+  rdfs:label "is assessment subject of"@en ;
+  iao:0000115 "Relates a reporting/management stratum or biological population to a stock assessment that evaluates it."@en ; # definition
+  rdfs:domain [ owl:unionOf ( gcdfo:ReportingOrManagementStratum gcdfo:Population ) ] ;
+  rdfs:range gcdfo:StockAssessment ;
+  owl:inverseOf gcdfo:hasAssessmentSubject ;
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:PolicyGovernanceTheme, gcdfo:DataModelProvenanceTheme .
+
+gcdfo:usesAssessmentDatum a owl:ObjectProperty ;
+  rdfs:label "uses assessment datum"@en ;
+  iao:0000115 "Relates a stock assessment to a measurement datum used as assessment input or evidence."@en ; # definition
+  rdfs:domain gcdfo:StockAssessment ;
+  rdfs:range [ owl:unionOf ( iao:0000109 gcdfo:ObservedRateOrAbundance gcdfo:TargetOrLimitRateOrAbundance ) ] ;
+  rdfs:comment "Range explicitly includes measurement datum plus common rate classes used in stock-assessment workflows."@en ;
+  owl:inverseOf gcdfo:isDatumUsedInAssessment ;
+  rdfs:subPropertyOf prov:used ;
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:DataModelProvenanceTheme .
+
+gcdfo:isDatumUsedInAssessment a owl:ObjectProperty ;
+  rdfs:label "is datum used in assessment"@en ;
+  iao:0000115 "Relates a measurement datum to a stock assessment process that uses it as evidence."@en ; # definition
+  rdfs:domain iao:0000109 ; # measurement datum
+  rdfs:range gcdfo:StockAssessment ;
+  owl:inverseOf gcdfo:usesAssessmentDatum ;
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:DataModelProvenanceTheme .
+
+gcdfo:hasAssessmentReferencePoint a owl:ObjectProperty ;
+  rdfs:label "has assessment reference point"@en ;
+  iao:0000115 "Relates a stock assessment process to a reference point used to interpret status or management risk."@en ; # definition
+  rdfs:domain gcdfo:StockAssessment ;
+  rdfs:range gcdfo:ReferencePoint ;
+  owl:inverseOf gcdfo:isAssessmentReferencePointFor ;
+  rdfs:subPropertyOf prov:used ;
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:FisheriesManagementTheme, gcdfo:PolicyGovernanceTheme .
+
+gcdfo:isAssessmentReferencePointFor a owl:ObjectProperty ;
+  rdfs:label "is assessment reference point for"@en ;
+  iao:0000115 "Relates a reference point to a stock assessment process that uses it for status interpretation or advice."@en ; # definition
+  rdfs:domain gcdfo:ReferencePoint ;
+  rdfs:range gcdfo:StockAssessment ;
+  owl:inverseOf gcdfo:hasAssessmentReferencePoint ;
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:FisheriesManagementTheme, gcdfo:PolicyGovernanceTheme .
 
 gcdfo:iadoptEntity a owl:AnnotationProperty ;
   rdfs:label "I-ADOPT entity"@en ;


### PR DESCRIPTION
## Summary
This PR closes the process-branch disconnect described in #40 by adding a minimal bridge layer between process terms and the core assessment graph.

### Ontology changes (minimal bridge surface)
Added three object-property pairs (with inverses):

- `gcdfo:hasAssessmentSubject` / `gcdfo:isAssessmentSubjectOf`
  - links `gcdfo:StockAssessment` to assessed entities (`gcdfo:ReportingOrManagementStratum` or `gcdfo:Population`)
- `gcdfo:usesAssessmentDatum` / `gcdfo:isDatumUsedInAssessment`
  - links `gcdfo:StockAssessment` to measurement/rate evidence
- `gcdfo:hasAssessmentReferencePoint` / `gcdfo:isAssessmentReferencePointFor`
  - links `gcdfo:StockAssessment` to management reference points

Also updated ontology metadata date (`dcterms:modified`) and regenerated docs artifacts via `make ci`.

## Reproduction + evidence
- Added analysis note: `docs/analyses/2026-03-02-issue-40-process-bridge.md`
- Baseline (`origin/main`) reproduction showed process branch reachability to key assessment targets as `False`.
- Post-patch verification shows reachability to:
  - `gcdfo:StockAssessment` ✅
  - `gcdfo:ReferencePoint` ✅
  - `gcdfo:ObservedRateOrAbundance` ✅
  - `gcdfo:TargetOrLimitRateOrAbundance` ✅
  - `iao:0000109` ✅

## Docs updates
- `docs/CONVENTIONS.md`: added guidance for when module disconnection is acceptable vs when bridge edges are required.
- `docs/COMPETENCY_QUESTIONS.md`: added 5 competency-query templates for process→assessment→reference-point traversal.

## Blast radius
Low and schema-focused:
- ✅ Added object properties only (no class removals/renames)
- ✅ No destructive ontology rewrites
- ✅ No changes to external IRIs
- ✅ Regenerated docs serializations and HTML reflect only this bridge addition

## Validation
- `make test` ✅
- `make ci` ✅
- Pre-push CI hook (`make ci`) ✅

Fixes #40
