### PR TITLE
docs: add route-term coverage inventory for wizard upload routes

### DIFF
--- a/docs/ontology_applications/FSAR_Tracer_PRD_CQs.md
+++ b/docs/ontology_applications/FSAR_Tracer_PRD_CQs.md
@@ -27,7 +27,7 @@
 - **Responsibilities:** Narrative coherence, benchmark justification, proxy rationale, reviewer response integration
 - **Stories:** 
   - Generate submission-ready trace packs with benchmarks, uncertainty notes, proxy decisions, and methods provenance; integrate reviewer feedback.
-  - Start a new submission via a **Metadata Intake wizard**: select SMU/CU/Population/PFMA/Indicator scope + Year, fill required metadata using **controlled‑vocab dropdowns** sourced from SKOS, attach filled in Excel/CSV template data.
+  - Start a new submission via a **Metadata Intake wizard**: select SMU/CU/Population/PFMA/IndicatorRiver scope + Year ("Indicator Stock" UI alias), fill required metadata using **controlled‑vocab dropdowns** sourced from SKOS, attach filled in Excel/CSV template data.
 - **Acceptance:** 
   - Lead Author can generate a "submission-ready" trace pack with benchmarks, uncertainty notes, proxy decisions, data sources and methods provenance.
   - Benchmark derivation method, input dataset(s), time window, uncertainty method, and version/date
@@ -51,7 +51,7 @@
 - **Goal:** Ensure data standards are met (terms, provenance, data quality, uncertainty); fail fast; identify missing metadata or poor data stewardship practices to help support FSAR authors meet best practices. Ship FSARs quickly. Upload draft data to check for compliance, completeness etc.
 - **Stories:**
   - Click **Validate** to run SHACL + R validator; see inline errors (row/column, severity, code, fix‑hint); correct and re‑validate until state = **Ready**.
-  - Save/resume drafts; download a tailored **Excel template** for the selected scope (Population, CU, SMU, Indicator Stock, PFMA) pre‑filled with valid enumerations.
+  - Save/resume drafts; download a tailored **Excel template** for the selected scope (Population, CU, SMU, IndicatorRiver [Indicator Stock alias], PFMA) pre‑filled with valid enumerations.
   - Open **Evidence Drawer** for provenance minimum and submission audit (who/when, validator versions).
 - **Acceptance:**
   - **Validator gating:** "Ready" is blocked unless all required metadata are present: method registry term + version, benchmark derivation record, data coverage window, unit + scale, provenance (PROV-O), and person‑time stamps (who/when).
@@ -183,7 +183,7 @@ This will be an interactive hierarchical tree style graph with progressive discl
 - **Step 2 — Attach files:** Upload `.xlsx` (current accepted format). Parse Metadata tab first; show a preview of parsed metadata fields.
 - **Step 3 — Validate:** Run SHACL + R validator; render inline errors (severity, row/col, code, fix‑hint). Provide "Re‑run validation" and "Download error report".
 - **Step 4 — Ready & Submit:** When no critical errors remain, mark **Ready**. Submissions require human review/approval before ingest to SPSR.
-- **Utilities:** "Download tailored template" endpoint pre‑seeds enumerations and column headers by scope (Population, CU, SMU, Indicator Stock, PFMA); "Save draft" persists current progress.
+- **Utilities:** "Download tailored template" endpoint pre‑seeds enumerations and column headers by scope (Population, CU, SMU, IndicatorRiver [Indicator Stock alias], PFMA); "Save draft" persists current progress.
 
 ## 2c) Usability & Data Input Workflow (Reduce Friction, Increase Trust)
 

--- a/draft/route-coverage/integrated-wizard-route-term-inventory.md
+++ b/draft/route-coverage/integrated-wizard-route-term-inventory.md
@@ -1,0 +1,37 @@
+# Integrated Wizard Route-Term Coverage Inventory
+
+Date: 2026-03-02  
+Scope: CU / SMU / PFMA / IndicatorRiver upload routes  
+Issue: #51  
+Kanban anchor: `step-1772475890-9a4b2c`
+
+## Method
+- Audited canonical ontology: `ontology/dfo-salmon.ttl` (origin/main).
+- Cross-checked wizard scope language in: `docs/ontology_applications/FSAR_Tracer_PRD_CQs.md`.
+- Classified each route as `present`, `missing`, or `ambiguous` based on explicit in-repo terms.
+
+## Route-Term Inventory Matrix
+
+| Upload route | Ontology term coverage | Status | Evidence | Gap class | Notes |
+|---|---|---|---|---|---|
+| CU | `gcdfo:ConservationUnit` (`https://w3id.org/gcdfo/salmon#ConservationUnit`) + supporting CU population relations (`gcdfo:hasPopulation`, `gcdfo:populationOf`) | present | `ontology/dfo-salmon.ttl:1675`, `:1418`, `:1426` | none | Core route entity and immediate composition relations exist. |
+| SMU | `gcdfo:StockManagementUnit` (`https://w3id.org/gcdfo/salmon#StockManagementUnit`) + CU linkage (`gcdfo:hasConservationUnit`, `gcdfo:conservationUnitOf`) | present | `ontology/dfo-salmon.ttl:1687`, `:1435`, `:1443` | none | Core route entity and CU composition linkage exist. |
+| PFMA | No explicit PFMA class/IRI found in ontology (`PFMA`, `Pacific Fishery Management Area`, `PacificFisheryManagementArea`) | missing | Wizard scope includes PFMA in `docs/ontology_applications/FSAR_Tracer_PRD_CQs.md:30,54,186`; ontology search returned no PFMA term matches | missing-term | Route exists in intake scope but lacks a corresponding ontology entity term. |
+| IndicatorRiver | `gcdfo:IndicatorRiver` (`https://w3id.org/gcdfo/salmon#IndicatorRiver`) exists; wizard docs now use IndicatorRiver with an explicit "Indicator Stock" UI alias | ambiguous | `ontology/dfo-salmon.ttl:1914`; wizard scope wording in `docs/ontology_applications/FSAR_Tracer_PRD_CQs.md:30,54,186` | terminology-alias + relation ambiguity | Core entity term exists, but route naming and expected relationship semantics need explicit policy mapping. |
+
+## Gap Classes Identified
+1. **Missing core entity term**
+   - PFMA route has no matching ontology class.
+2. **Terminology alias ambiguity**
+   - Indicator route naming currently uses canonical `IndicatorRiver` plus an "Indicator Stock" UI alias that should be governed explicitly.
+3. **Relationship-model ambiguity (IndicatorRiver/PFMA routes)**
+   - Explicit route-level relation properties to CU/SMU/Population are not yet formalized for these scopes.
+
+## Recommended Next Patch Slice
+1. **Add PFMA as a minimal, evidence-backed class**
+   - Introduce `gcdfo:PacificFisheryManagementArea` (or agreed canonical label) as subclass of `gcdfo:ReportingOrManagementStratum`.
+   - Include `skos:altLabel "PFMA"@en` and citation-backed definition/source.
+2. **Lock route naming contract in docs**
+   - Keep `IndicatorRiver` as ontology term with "Indicator Stock" as UI alias (documented explicitly).
+3. **Defer new relationship properties until evidence is cited**
+   - Add relation terms only after confirming operational semantics from source policy/docs.


### PR DESCRIPTION
## Summary
Implements the issue-first kickoff for route-level ontology coverage across wizard upload routes (CU/SMU/PFMA/IndicatorRiver).

Closes #51.

## What changed
1. Added initial route-term inventory matrix artifact:
   - `draft/route-coverage/integrated-wizard-route-term-inventory.md`
2. Added minimal low-risk documentation alignment for Indicator route naming in:
   - `docs/ontology_applications/FSAR_Tracer_PRD_CQs.md`
   - Uses `IndicatorRiver` as canonical ontology scope with explicit "Indicator Stock" UI alias.

## Gap classes identified
- **missing-term:** PFMA route has no corresponding ontology class/IRI.
- **terminology-alias ambiguity:** Indicator route uses canonical + UI alias language.
- **relation ambiguity:** Route-level relation semantics for IndicatorRiver/PFMA to CU/SMU/Population are not explicit.

## Recommended next patch slice
1. Add a minimal evidence-backed PFMA class (likely under `ReportingOrManagementStratum`) with `PFMA` alias + citation.
2. Keep Indicator naming contract explicit (`IndicatorRiver` canonical, "Indicator Stock" UI alias).
3. Defer new relation properties until source policy/docs confirm semantics.

## Notes
- This PR intentionally avoids speculative ontology expansion.
- No force-push/history rewrite used.
