### PR TITLE
feat: add minimal PFMA class coverage for integrated wizard route

### DIFF
--- a/docs/gcdfo.jsonld
+++ b/docs/gcdfo.jsonld
@@ -5992,6 +5992,62 @@
     ]
   },
   {
+    "@id": "https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000115": [
+      {
+        "@language": "en",
+        "@value": "A reporting and management stratum representing a prescribed Pacific fishery management area in Canadian fisheries waters of the Pacific Ocean."
+      }
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000119": [
+      {
+        "@language": "en",
+        "@value": "Government of Canada. Pacific Fishery Management Area Regulations, 2007 (SOR/2007-77): management area means a division of Canadian fisheries waters as enumerated and described in Schedule 2. https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html."
+      }
+    ],
+    "http://purl.org/dc/terms/source": [
+      {
+        "@id": "https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Pacific fishery management area"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#altLabel": [
+      {
+        "@language": "en",
+        "@value": "PFMA"
+      }
+    ],
+    "https://w3id.org/gcdfo/salmon#theme": [
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"
+      },
+      {
+        "@id": "https://w3id.org/gcdfo/salmon#StockAssessmentTheme"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/gcdfo/salmon#PeakCountAnalysis",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"

--- a/docs/gcdfo.owl
+++ b/docs/gcdfo.owl
@@ -1420,6 +1420,23 @@
     
 
 
+    <!-- https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea -->
+
+    <owl:Class rdf:about="https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum"/>
+        <obo:IAO_0000115 xml:lang="en">A reporting and management stratum representing a prescribed Pacific fishery management area in Canadian fisheries waters of the Pacific Ocean.</obo:IAO_0000115>
+        <obo:IAO_0000119 xml:lang="en">Government of Canada. Pacific Fishery Management Area Regulations, 2007 (SOR/2007-77): management area means a division of Canadian fisheries waters as enumerated and described in Schedule 2. https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html.</obo:IAO_0000119>
+        <dcterms:source rdf:resource="https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Pacific fishery management area</rdfs:label>
+        <skos:altLabel xml:lang="en">PFMA</skos:altLabel>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"/>
+        <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/gcdfo/salmon#Population -->
 
     <owl:Class rdf:about="https://w3id.org/gcdfo/salmon#Population">

--- a/docs/gcdfo.ttl
+++ b/docs/gcdfo.ttl
@@ -1053,6 +1053,20 @@ gcdfo:OceanMortalityRate rdf:type owl:Class ;
                          gcdfo:theme gcdfo:StockAssessmentTheme .
 
 
+###  https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea
+gcdfo:PacificFisheryManagementArea rdf:type owl:Class ;
+                                   rdfs:subClassOf gcdfo:ReportingOrManagementStratum ;
+                                   <http://purl.obolibrary.org/obo/IAO_0000115> "A reporting and management stratum representing a prescribed Pacific fishery management area in Canadian fisheries waters of the Pacific Ocean."@en ;
+                                   <http://purl.obolibrary.org/obo/IAO_0000119> "Government of Canada. Pacific Fishery Management Area Regulations, 2007 (SOR/2007-77): management area means a division of Canadian fisheries waters as enumerated and described in Schedule 2. https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html."@en ;
+                                   dcterms:source <https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html> ;
+                                   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                   rdfs:label "Pacific fishery management area"@en ;
+                                   skos:altLabel "PFMA"@en ;
+                                   gcdfo:theme gcdfo:FisheriesManagementTheme ,
+                                               gcdfo:PolicyGovernanceTheme ,
+                                               gcdfo:StockAssessmentTheme .
+
+
 ###  https://w3id.org/gcdfo/salmon#Population
 gcdfo:Population rdf:type owl:Class ;
                  rdfs:subClassOf dwc:Organism ;

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -240,6 +240,10 @@ This ontology has the following classes and properties.</span>
       <a href="#http://rs.tdwg.org/dwc/terms/Organism" title="http://rs.tdwg.org/dwc/terms/Organism">Organism</a>
    </li>
    <li>
+      <a href="#PacificFisheryManagementArea"
+         title="https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea">Pacific fishery management area</a>
+   </li>
+   <li>
       <a href="#http://purl.obolibrary.org/obo/IAO_0000104" title="http://purl.obolibrary.org/obo/IAO_0000104">plan specification</a>
    </li>
    <li>
@@ -532,6 +536,7 @@ This section provides details for each class and property defined by DFO Salmon 
   <li><a href="#http://rs.tdwg.org/dwc/terms/Occurrence" title="http://rs.tdwg.org/dwc/terms/Occurrence">Occurrence</a></li>
   <li><a href="#OceanMortalityRate" title="https://w3id.org/gcdfo/salmon#OceanMortalityRate">Ocean mortality rate</a></li>
   <li><a href="#http://rs.tdwg.org/dwc/terms/Organism" title="http://rs.tdwg.org/dwc/terms/Organism">Organism</a></li>
+  <li><a href="#PacificFisheryManagementArea" title="https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea">Pacific fishery management area</a></li>
   <li><a href="#http://purl.obolibrary.org/obo/IAO_0000104" title="http://purl.obolibrary.org/obo/IAO_0000104">plan specification</a></li>
   <li><a href="#http://purl.obolibrary.org/obo/ENVO_00000033" title="http://purl.obolibrary.org/obo/ENVO_00000033">pond</a></li>
   <li><a href="#Population" title="https://w3id.org/gcdfo/salmon#Population">Population</a></li>
@@ -1813,6 +1818,40 @@ This section provides details for each class and property defined by DFO Salmon 
    </dd>
   </dl>
  </div>
+ <div class="entity" id="PacificFisheryManagementArea">
+  <h3>Pacific fishery management area<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea</p>
+  <div class="comment">
+   <span class="markdown">A reporting and management stratum representing a prescribed Pacific fishery management area in Canadian fisheries waters of the Pacific Ocean.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <dl class="definedBy">
+   <dt>
+    Source
+   </dt>
+   <dd>
+    Government of Canada. Pacific Fishery Management Area Regulations, 2007 (SOR/2007-77): management area means a division of Canadian fisheries waters as enumerated and described in Schedule 2. https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html.
+   </dd>
+   <dd>
+    <a href="https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html">https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    has super-classes
+   </dt>
+   <dd>
+    <a href="#ReportingOrManagementStratum" title="https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum">Reporting or management stratum</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+  </dl>
+ </div>
  <div class="entity" id="http://purl.obolibrary.org/obo/IAO_0000104">
   <h3>plan specification<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> http://purl.obolibrary.org/obo/IAO_0000104</p>
@@ -2537,7 +2576,7 @@ This section provides details for each class and property defined by DFO Salmon 
     has sub-classes
    </dt>
    <dd>
-    <a href="#ConservationUnit" title="https://w3id.org/gcdfo/salmon#ConservationUnit">Conservation Unit</a> <sup class="type-c" title="class">c</sup>, <a href="#IndicatorRiver" title="https://w3id.org/gcdfo/salmon#IndicatorRiver">Indicator river</a> <sup class="type-c" title="class">c</sup>, <a href="#Stock" title="https://w3id.org/gcdfo/salmon#Stock">Stock</a> <sup class="type-c" title="class">c</sup>, <a href="#StockManagementUnit" title="https://w3id.org/gcdfo/salmon#StockManagementUnit">Stock Management Unit</a> <sup class="type-c" title="class">c</sup>
+    <a href="#ConservationUnit" title="https://w3id.org/gcdfo/salmon#ConservationUnit">Conservation Unit</a> <sup class="type-c" title="class">c</sup>, <a href="#IndicatorRiver" title="https://w3id.org/gcdfo/salmon#IndicatorRiver">Indicator river</a> <sup class="type-c" title="class">c</sup>, <a href="#PacificFisheryManagementArea" title="https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea">Pacific fishery management area</a> <sup class="type-c" title="class">c</sup>, <a href="#Stock" title="https://w3id.org/gcdfo/salmon#Stock">Stock</a> <sup class="type-c" title="class">c</sup>, <a href="#StockManagementUnit" title="https://w3id.org/gcdfo/salmon#StockManagementUnit">Stock Management Unit</a> <sup class="type-c" title="class">c</sup>
    </dd>
    <dt>
     is in domain of
@@ -4402,6 +4441,11 @@ This section provides details for each class and property defined by DFO Salmon 
 <li><a href="#OceanMortalityRate">https://w3id.org/gcdfo/salmon#OceanMortalityRate</a>
 <ul>
 <li>Added: SubClass of https://w3id.org/gcdfo/salmon#ObservedRateOrAbundance</li>
+</ul>
+</li>
+<li><a href="#PacificFisheryManagementArea">https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea</a>
+<ul>
+<li>Added: SubClass of https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum</li>
 </ul>
 </li>
 <li><a href="#Population">https://w3id.org/gcdfo/salmon#Population</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -584,7 +584,7 @@ $(function(){
     <div id="overview"><h2 id="overv" class="list">DFO Salmon Ontology: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
-<h4>Classes</h4><details class="gcdfo-collapsible gcdfo-overview-collapsible" open><summary>81 items (expand)</summary><ul xmlns:widoco="https://w3id.org/widoco/vocab#"
+<h4>Classes</h4><details class="gcdfo-collapsible gcdfo-overview-collapsible" open><summary>82 items (expand)</summary><ul xmlns:widoco="https://w3id.org/widoco/vocab#"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     class="hlist">
    <li>
@@ -712,6 +712,10 @@ This ontology has the following classes and properties.</span>
    </li>
    <li>
       <a href="#http://rs.tdwg.org/dwc/terms/Organism" title="http://rs.tdwg.org/dwc/terms/Organism">Organism</a>
+   </li>
+   <li>
+      <a href="#PacificFisheryManagementArea"
+         title="https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea">Pacific fishery management area</a>
    </li>
    <li>
       <a href="#http://purl.obolibrary.org/obo/IAO_0000104" title="http://purl.obolibrary.org/obo/IAO_0000104">plan specification</a>
@@ -3476,6 +3480,7 @@ This section provides details for each class and property defined by DFO Salmon 
   <li><a href="#http://rs.tdwg.org/dwc/terms/Occurrence" title="http://rs.tdwg.org/dwc/terms/Occurrence">Occurrence</a></li>
   <li><a href="#OceanMortalityRate" title="https://w3id.org/gcdfo/salmon#OceanMortalityRate">Ocean mortality rate</a></li>
   <li><a href="#http://rs.tdwg.org/dwc/terms/Organism" title="http://rs.tdwg.org/dwc/terms/Organism">Organism</a></li>
+  <li><a href="#PacificFisheryManagementArea" title="https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea">Pacific fishery management area</a></li>
   <li><a href="#http://purl.obolibrary.org/obo/IAO_0000104" title="http://purl.obolibrary.org/obo/IAO_0000104">plan specification</a></li>
   <li><a href="#http://purl.obolibrary.org/obo/ENVO_00000033" title="http://purl.obolibrary.org/obo/ENVO_00000033">pond</a></li>
   <li><a href="#Population" title="https://w3id.org/gcdfo/salmon#Population">Population</a></li>
@@ -4757,6 +4762,40 @@ This section provides details for each class and property defined by DFO Salmon 
    </dd>
   </dl>
  </div>
+ <div class="entity" id="PacificFisheryManagementArea">
+  <h3>Pacific fishery management area<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea</p>
+  <div class="comment">
+   <span class="markdown">A reporting and management stratum representing a prescribed Pacific fishery management area in Canadian fisheries waters of the Pacific Ocean.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+   </dd>
+  </dl>
+  <dl class="definedBy">
+   <dt>
+    Source
+   </dt>
+   <dd>
+    Government of Canada. Pacific Fishery Management Area Regulations, 2007 (SOR/2007-77): management area means a division of Canadian fisheries waters as enumerated and described in Schedule 2. https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html.
+   </dd>
+   <dd>
+    <a href="https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html">https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    has super-classes
+   </dt>
+   <dd>
+    <a href="#ReportingOrManagementStratum" title="https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum">Reporting or management stratum</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+  </dl>
+ </div>
  <div class="entity" id="http://purl.obolibrary.org/obo/IAO_0000104">
   <h3>plan specification<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> http://purl.obolibrary.org/obo/IAO_0000104</p>
@@ -5481,7 +5520,7 @@ This section provides details for each class and property defined by DFO Salmon 
     has sub-classes
    </dt>
    <dd>
-    <a href="#ConservationUnit" title="https://w3id.org/gcdfo/salmon#ConservationUnit">Conservation Unit</a> <sup class="type-c" title="class">c</sup>, <a href="#IndicatorRiver" title="https://w3id.org/gcdfo/salmon#IndicatorRiver">Indicator river</a> <sup class="type-c" title="class">c</sup>, <a href="#Stock" title="https://w3id.org/gcdfo/salmon#Stock">Stock</a> <sup class="type-c" title="class">c</sup>, <a href="#StockManagementUnit" title="https://w3id.org/gcdfo/salmon#StockManagementUnit">Stock Management Unit</a> <sup class="type-c" title="class">c</sup>
+    <a href="#ConservationUnit" title="https://w3id.org/gcdfo/salmon#ConservationUnit">Conservation Unit</a> <sup class="type-c" title="class">c</sup>, <a href="#IndicatorRiver" title="https://w3id.org/gcdfo/salmon#IndicatorRiver">Indicator river</a> <sup class="type-c" title="class">c</sup>, <a href="#PacificFisheryManagementArea" title="https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea">Pacific fishery management area</a> <sup class="type-c" title="class">c</sup>, <a href="#Stock" title="https://w3id.org/gcdfo/salmon#Stock">Stock</a> <sup class="type-c" title="class">c</sup>, <a href="#StockManagementUnit" title="https://w3id.org/gcdfo/salmon#StockManagementUnit">Stock Management Unit</a> <sup class="type-c" title="class">c</sup>
    </dd>
    <dt>
     is in domain of
@@ -7346,6 +7385,11 @@ This section provides details for each class and property defined by DFO Salmon 
 <li><a href="#OceanMortalityRate">https://w3id.org/gcdfo/salmon#OceanMortalityRate</a>
 <ul>
 <li>Added: SubClass of https://w3id.org/gcdfo/salmon#ObservedRateOrAbundance</li>
+</ul>
+</li>
+<li><a href="#PacificFisheryManagementArea">https://w3id.org/gcdfo/salmon#PacificFisheryManagementArea</a>
+<ul>
+<li>Added: SubClass of https://w3id.org/gcdfo/salmon#ReportingOrManagementStratum</li>
 </ul>
 </li>
 <li><a href="#Population">https://w3id.org/gcdfo/salmon#Population</a>

--- a/docs/ontology_applications/FSAR_Tracer_PRD_CQs.md
+++ b/docs/ontology_applications/FSAR_Tracer_PRD_CQs.md
@@ -184,6 +184,10 @@ This will be an interactive hierarchical tree style graph with progressive discl
 - **Step 3 — Validate:** Run SHACL + R validator; render inline errors (severity, row/col, code, fix‑hint). Provide "Re‑run validation" and "Download error report".
 - **Step 4 — Ready & Submit:** When no critical errors remain, mark **Ready**. Submissions require human review/approval before ingest to SPSR.
 - **Utilities:** "Download tailored template" endpoint pre‑seeds enumerations and column headers by scope (Population, CU, SMU, IndicatorRiver [Indicator Stock alias], PFMA); "Save draft" persists current progress.
+- **Route naming contract (ontology ↔ UI):**
+  - Canonical ontology route terms: `ConservationUnit`, `StockManagementUnit`, `PacificFisheryManagementArea`, `IndicatorRiver`.
+  - UI may display `IndicatorRiver` as **Indicator Stock** for legacy continuity, but persisted/API term mapping remains `IndicatorRiver`.
+  - UI may display `PacificFisheryManagementArea` as **PFMA** shorthand, but persisted/API term mapping remains `PacificFisheryManagementArea`.
 
 ## 2c) Usability & Data Input Workflow (Reduce Friction, Increase Trust)
 

--- a/draft/route-coverage/integrated-wizard-route-term-inventory.md
+++ b/draft/route-coverage/integrated-wizard-route-term-inventory.md
@@ -35,3 +35,14 @@ Kanban anchor: `step-1772475890-9a4b2c`
    - Keep `IndicatorRiver` as ontology term with "Indicator Stock" as UI alias (documented explicitly).
 3. **Defer new relationship properties until evidence is cited**
    - Add relation terms only after confirming operational semantics from source policy/docs.
+
+## Patch Slice Status Update (2026-03-02)
+Applied in follow-up route-coverage patch:
+- Added `gcdfo:PacificFisheryManagementArea` as a minimal class under `gcdfo:ReportingOrManagementStratum` with `skos:altLabel "PFMA"@en` and citation to the Pacific Fishery Management Area Regulations, 2007.
+- Added explicit wizard route naming contract language in `docs/ontology_applications/FSAR_Tracer_PRD_CQs.md`:
+  - canonical ontology terms (`IndicatorRiver`, `PacificFisheryManagementArea`) remain canonical for persistence/API
+  - UI aliases `Indicator Stock` and `PFMA` are display-only mappings
+
+### Remaining Gap Classes After This Slice
+1. **Relationship-model ambiguity (IndicatorRiver/PFMA routes)**
+   - Route-level relation property semantics to CU/SMU/Population are still intentionally deferred pending source-backed policy/operational evidence.

--- a/ontology/dfo-salmon.ttl
+++ b/ontology/dfo-salmon.ttl
@@ -1694,6 +1694,16 @@ gcdfo:StockManagementUnit a owl:Class ;
   gcdfo:theme gcdfo:FisheriesManagementTheme, gcdfo:StockAssessmentTheme, gcdfo:PolicyGovernanceTheme ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
 
+gcdfo:PacificFisheryManagementArea a owl:Class ;
+  rdfs:label "Pacific fishery management area"@en ;
+  iao:0000115 "A reporting and management stratum representing a prescribed Pacific fishery management area in Canadian fisheries waters of the Pacific Ocean."@en ; # definition
+  skos:altLabel "PFMA"@en ;
+  rdfs:subClassOf gcdfo:ReportingOrManagementStratum ;
+  iao:0000119 "Government of Canada. Pacific Fishery Management Area Regulations, 2007 (SOR/2007-77): management area means a division of Canadian fisheries waters as enumerated and described in Schedule 2. https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html."@en ; # definition source
+  dcterms:source <https://laws-lois.justice.gc.ca/eng/regulations/sor-2007-77/page-1.html> ;
+  gcdfo:theme gcdfo:FisheriesManagementTheme, gcdfo:StockAssessmentTheme, gcdfo:PolicyGovernanceTheme ;
+  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+
 gcdfo:Escapement a owl:Class ;
   rdfs:label "Escapement"@en ;
   rdfs:subClassOf bfo:0000015 ; # process


### PR DESCRIPTION
## Summary
- add minimal `gcdfo:PacificFisheryManagementArea` class as a subclass of `gcdfo:ReportingOrManagementStratum`
- include `skos:altLabel "PFMA"@en` and citation-backed definition/source (Pacific Fishery Management Area Regulations, 2007)
- keep route naming contract explicit in wizard docs (`IndicatorRiver` canonical + "Indicator Stock" UI alias; `PacificFisheryManagementArea` canonical + "PFMA" UI alias)
- update route inventory artifact with a patch-slice status update and remaining gap class

## Scope guardrails
- no new relation properties added in this slice
- relation-property expansion for IndicatorRiver/PFMA remains intentionally deferred pending source-backed semantics

## Checks run
- `PATH="/usr/local/opt/openjdk@17/bin:$PATH" make ci` ✅
  - theme coverage: pass
  - alpha SPARQL lints: pass
  - ELK reasoning: pass
  - ROBOT quality-check: pass (0 ERROR, 0 WARN; expected INFO only)
  - docs refresh + serializations: pass

Refs #51
