### PR TITLE
Align README guidance with annotation conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If a term is clearly **cross-organization, policy-neutral, and reusable**, it pr
 - **GitHub-based collaboration**: all changes via Pull Requests with Issues for discussion.
 - **Quality first**: use competency questions and design patterns to guide development.
 - **Before creating terms**: search existing terms and check competency questions.
-- **Document everything per the conventions checklist**: for OWL terms use `rdfs:label`, `iao:0000115`, and `rdfs:isDefinedBy`; add `iao:0000119` and/or `dcterms:source` when authoritative provenance exists; use `rdfs:comment` only for editorial notes.
+- **Document everything per the conventions checklist**: for OWL terms use `rdfs:label`, `iao:0000115`, and `rdfs:isDefinedBy`; add `iao:0000119` and/or `dcterms:source` when authoritative provenance exists; use `rdfs:comment` only for editorial notes. `rdfs:isDefinedBy` must follow term ownership (`gcdfo:` → GCDFO, shared `smn:` → SMN).
 - **Test with data**: validate terms with sample data and SPARQL queries.
 
 **For detailed modeling conventions, see [GC DFO Salmon Ontology Conventions Guide](docs/CONVENTIONS.md).**

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If a term is clearly **cross-organization, policy-neutral, and reusable**, it pr
 - **GitHub-based collaboration**: all changes via Pull Requests with Issues for discussion.
 - **Quality first**: use competency questions and design patterns to guide development.
 - **Before creating terms**: search existing terms and check competency questions.
-- **Document everything**: always include `rdfs:comment` and `dcterms:source`.
+- **Document everything per the conventions checklist**: for OWL terms use `rdfs:label`, `iao:0000115`, and `rdfs:isDefinedBy`; add `iao:0000119` and/or `dcterms:source` when authoritative provenance exists; use `rdfs:comment` only for editorial notes.
 - **Test with data**: validate terms with sample data and SPARQL queries.
 
 **For detailed modeling conventions, see [GC DFO Salmon Ontology Conventions Guide](docs/CONVENTIONS.md).**

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -200,7 +200,7 @@ The `ontology/dfo-salmon.ttl` file must contain **schema elements only** - no in
 - **Type declaration:** `a owl:Class` - This tells the system this is a class
 - **Label:** `rdfs:label "Human Name"@en` - A human-readable name in English (required, one per language)
 - **Definition:** `iao:0000115 "1–2 sentence definition."@en` - A clear explanation of what this class represents (required, one only)
-- **Source attribution:** `rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon>` - Links back to our ontology (required)
+- **Source attribution:** `rdfs:isDefinedBy <owning ontology IRI>` - Required. This must follow term ownership, not just the file you are editing. Use `https://w3id.org/gcdfo/salmon` for `gcdfo:` terms, `https://w3id.org/smn` for shared `smn:` terms, and the external ontology IRI for imported external terms.
 
 **Optional elements:**
 
@@ -235,7 +235,7 @@ The `ontology/dfo-salmon.ttl` file must contain **schema elements only** - no in
 - **Type declaration:** `a owl:ObjectProperty`
 - **Label:** `rdfs:label "Human Name"@en` - A human-readable name (required, one per language)
 - **Definition:** `iao:0000115 "1–2 sentence definition."@en` - A clear explanation of what this property represents (required, one only)
-- **Source attribution:** `rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon>` - Links back to our ontology (required)
+- **Source attribution:** `rdfs:isDefinedBy <owning ontology IRI>` - Required. Use the ontology that owns the property IRI (`gcdfo:` → `https://w3id.org/gcdfo/salmon`, shared `smn:` → `https://w3id.org/smn`).
 
 **Optional but recommended:**
 
@@ -280,7 +280,7 @@ Do not use `rdfs:seeAlso` for semantic alignment.
 - **Type declaration:** `a owl:DatatypeProperty`
 - **Label:** `rdfs:label "Human Name"@en` - A human-readable name (required, one per language)
 - **Definition:** `iao:0000115 "1–2 sentence definition."@en` - A clear explanation of what this property represents (required, one only)
-- **Source attribution:** `rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon>` - Links back to our ontology (required)
+- **Source attribution:** `rdfs:isDefinedBy <owning ontology IRI>` - Required. Use the ontology that owns the property IRI (`gcdfo:` → `https://w3id.org/gcdfo/salmon`, shared `smn:` → `https://w3id.org/smn`).
 
 **Optional but recommended:**
 
@@ -324,7 +324,7 @@ Do not use `rdfs:seeAlso` for semantic alignment.
 - **Label:** `skos:prefLabel "Human Name"@en` - A human-readable name (required, ≤1 per language)
 - **Scheme membership:** `skos:inScheme :SchemeName` - The concept scheme this concept belongs to (required)
 - **Definition:** `skos:definition "1–2 sentence definition."@en` - A clear explanation (recommended, 1×)
-- **Source attribution:** `rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon>` - Links back to our ontology (required)
+- **Source attribution:** `rdfs:isDefinedBy <owning ontology IRI>` - Required. Use the ontology that owns the concept IRI (`gcdfo:` → `https://w3id.org/gcdfo/salmon`, shared `smn:` → `https://w3id.org/smn`).
 
 **Optional elements:**
 
@@ -1773,7 +1773,7 @@ Use inverse properties where they materially improve query ergonomics.
 - **Properties**: Import RO and reuse, or map via `owl:equivalentProperty` / `rdfs:subPropertyOf`
 - **Classes**: Import external ontologies or map via `owl:equivalentClass` / `rdfs:subClassOf`
 - **SKOS concepts**: Use `skos:exactMatch`/`skos:closeMatch` only for concept-level mappings
-- **rdfs:isDefinedBy**: Point at your ontology/module IRI (required)
+- **rdfs:isDefinedBy**: Point at the ontology/module that owns the term IRI (required). Do not point shared `smn:` terms at GCDFO just because they are referenced in `dfo-salmon.ttl`.
 - **rdfs:seeAlso**: Use only for helpful extra links, not for semantic alignment
 - Store external IRIs as literals in `…UnitIRI` properties (for units, may transition to object properties)
 - Use `dcterms:source` to reference external vocabularies

--- a/docs/gcdfo.jsonld
+++ b/docs/gcdfo.jsonld
@@ -11262,7 +11262,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -11306,7 +11306,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -11339,7 +11339,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -11398,7 +11398,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -11434,7 +11434,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -11473,7 +11473,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -11526,7 +11526,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -11568,7 +11568,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -11618,7 +11618,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -11662,7 +11662,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -11717,7 +11717,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -11756,7 +11756,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -11789,7 +11789,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -11839,7 +11839,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -11878,7 +11878,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -11916,7 +11916,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -11952,7 +11952,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -12011,7 +12011,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12052,7 +12052,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -12102,7 +12102,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12132,7 +12132,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -12188,7 +12188,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12244,7 +12244,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12283,7 +12283,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12313,7 +12313,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -12351,7 +12351,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -12387,7 +12387,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -12426,7 +12426,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -12481,7 +12481,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12537,7 +12537,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12581,7 +12581,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12617,7 +12617,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -12661,7 +12661,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12694,7 +12694,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -12738,7 +12738,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12779,7 +12779,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12825,7 +12825,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12872,7 +12872,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -12919,7 +12919,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "https://w3id.org/gcdfo/salmon"
+        "@id": "https://w3id.org/smn"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [

--- a/docs/gcdfo.jsonld
+++ b/docs/gcdfo.jsonld
@@ -6942,6 +6942,12 @@
         "@value": "High rapid-status confidence"
       }
     ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Rapid status confidence category indicating that high-quality abundance metrics support the result."
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme"
@@ -6985,6 +6991,12 @@
         "@value": "Low rapid-status confidence"
       }
     ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone)."
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme"
@@ -7026,6 +7038,12 @@
       {
         "@language": "en",
         "@value": "Medium rapid-status confidence"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -11062,6 +11080,12 @@
     "@id": "https://w3id.org/gcdfo/salmon#theme",
     "@type": [
       "http://www.w3.org/2002/07/owl#AnnotationProperty"
+    ],
+    "http://purl.obolibrary.org/obo/IAO_0000115": [
+      {
+        "@language": "en",
+        "@value": "Associates OWL classes and SKOS concepts with high-level thematic concept schemes (e.g., Stock Assessment, GSI, Policy)."
+      }
     ],
     "http://www.w3.org/2000/01/rdf-schema#comment": [
       {

--- a/docs/gcdfo.jsonld
+++ b/docs/gcdfo.jsonld
@@ -1324,6 +1324,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Absolute abundance metric status"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
       {
         "@language": "en",
@@ -1415,6 +1421,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Abundance data type"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/MeasurementContext"
@@ -1480,6 +1492,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Abundance percentile metric"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -1549,6 +1567,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Abundance percentile metric status"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -1628,6 +1652,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Aerial Survey Count"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/EnumerationMethod"
@@ -1667,6 +1697,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age 1 year class"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -1713,6 +1749,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age 2 year class"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#AgeClassValue"
@@ -1755,6 +1797,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age 3 year class"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -1801,6 +1849,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age 4 year class"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#AgeClassValue"
@@ -1843,6 +1897,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age 5 year class"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -1889,6 +1949,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age 6 year class"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#AgeClassValue"
@@ -1931,6 +1997,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age 7 year class"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -1977,6 +2049,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age at maturity basis"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#AgeBasis"
@@ -2016,6 +2094,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age at return basis"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -2059,6 +2143,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age at sampling basis"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#AgeBasis"
@@ -2098,6 +2188,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age basis"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -2172,6 +2268,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age class value"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -2238,6 +2340,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age dimension"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -2302,6 +2410,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Age notation"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -2389,6 +2503,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Amber zone"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -2432,6 +2552,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Area Under the Curve"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -2527,6 +2653,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Benchmark ratio metric"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -2638,6 +2770,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Bypass/Breach Risk"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -2694,6 +2832,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Brood year"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -2840,6 +2984,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Calibrated Time Series"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#EstimateMethod"
@@ -2885,6 +3035,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Catch year"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -2934,6 +3090,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Classification"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -2973,6 +3135,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Confidence category"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -3078,6 +3246,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Conservation Unit name"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
       {
         "@language": "en",
@@ -3145,6 +3319,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Cross-section Coverage"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -3186,6 +3366,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Data, Models, and Provenance"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -3217,6 +3403,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Data quality rating context"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -3261,6 +3453,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Detectability"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -3310,6 +3508,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Device Configuration"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -3357,6 +3561,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Documentation"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -3396,6 +3606,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Downgrade Criteria"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -3473,6 +3689,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Effort Standardization"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -3518,6 +3740,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Electrofishing Count"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -3600,6 +3828,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Environmental Conditions"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -3639,6 +3873,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Estimate Method"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -3708,6 +3948,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Estimate Type"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -3784,6 +4030,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "European age notation"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#AgeNotation"
@@ -3848,6 +4100,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Expansion factor"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#ExpansionMathematicalOperations"
@@ -3895,6 +4153,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Expansion/Mathematical Operations"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#EstimateMethod"
@@ -3934,6 +4198,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Fish Stocks Provisions"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -3986,6 +4256,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Fisheries Management"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -4023,6 +4299,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Fixed Site Census (Electronic)"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -4072,6 +4354,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Fixed Site Census (Manual)"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/EnumerationMethod"
@@ -4113,6 +4401,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Fixed‑Station Tally"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#EstimateMethod"
@@ -4152,6 +4446,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Freshwater age dimension"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -4207,6 +4507,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Generational average abundance"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -4273,6 +4579,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Genetics and Stock Composition"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -4309,6 +4621,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Gilbert-Rich age notation"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -4377,6 +4695,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Green zone"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -4422,6 +4746,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Habitat, Ecosystem, and Climate Pressures"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -4459,6 +4789,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Hydroacoustic Modelling"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -4506,6 +4842,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Hydroacoustic Sonar Count"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -4602,6 +4944,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Infill Method"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -4653,6 +5001,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Amber/Green integrated status"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -4711,6 +5065,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Integrated status (binary red/not-red)"
       }
     ],
     "http://www.w3.org/2002/07/owl#deprecated": [
@@ -4787,6 +5147,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Collapsed integrated status code"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -4867,6 +5233,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Data deficient integrated status"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -4915,6 +5287,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Integrated status (5-category legacy alias)"
       }
     ],
     "http://www.w3.org/2002/07/owl#deprecated": [
@@ -4990,6 +5368,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Not-red integrated status"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -5033,6 +5417,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Integrated status outcome"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -5115,6 +5505,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Integrated status (raw)"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
       {
         "@language": "en",
@@ -5189,6 +5585,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Raw integrated status code"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -5269,6 +5671,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Red/Amber integrated status"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -5325,6 +5733,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Integrated status (3-category collapsed)"
       }
     ],
     "http://www.w3.org/2002/07/owl#deprecated": [
@@ -5410,6 +5824,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Undetermined integrated status"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
       {
         "@language": "en",
@@ -5476,6 +5896,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Long-term trend metric"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -5547,6 +5973,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Long-term trend metric status"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
       {
         "@language": "en",
@@ -5616,6 +6048,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Lower benchmark"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -5748,6 +6186,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Management reference context"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/MeasurementContext"
@@ -5842,6 +6286,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Mark-Recapture Analysis"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#EstimateMethod"
@@ -5887,6 +6337,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Mark-Recapture Assumptions"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -5936,6 +6392,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Mark-Recapture Field Program"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/EnumerationMethod"
@@ -5983,6 +6445,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Method Unknown/Inconsistent"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -6024,6 +6492,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Monitoring and Field Work"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -6061,6 +6535,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Number of Visits"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -6155,6 +6635,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Ocean age dimension"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -6307,6 +6793,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Peak Count Analysis"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#EstimateMethod"
@@ -6363,6 +6855,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Percent change metric"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -6440,6 +6938,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Percent change metric status"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
       {
         "@language": "en",
@@ -6509,6 +7013,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Policy framework"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -6589,6 +7099,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Policy, Governance, and Organizational Structure"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -6620,6 +7136,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Precautionary Approach"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -6678,6 +7200,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Precision/Accuracy"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -6734,6 +7262,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Probability of decline below lower benchmark metric"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -6803,6 +7337,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Probability-of-decline-below-lower-benchmark metric status"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -6939,6 +7479,12 @@
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
+        "@value": "High confidence"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#altLabel": [
+      {
+        "@language": "en",
         "@value": "High rapid-status confidence"
       }
     ],
@@ -6988,6 +7534,12 @@
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
+        "@value": "Low confidence"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#altLabel": [
+      {
+        "@language": "en",
         "@value": "Low rapid-status confidence"
       }
     ],
@@ -7035,6 +7587,12 @@
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Medium confidence"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#altLabel": [
       {
         "@language": "en",
         "@value": "Medium rapid-status confidence"
@@ -7110,6 +7668,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Rapid status metric"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -7217,6 +7781,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Rapid status score metric"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#RapidStatusMetric"
@@ -7287,6 +7857,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Reach Coverage"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -7326,6 +7902,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Recruit stage context"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -7379,6 +7961,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Red zone"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -7430,6 +8018,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Redd Count"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/EnumerationMethod"
@@ -7477,6 +8071,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Redd Expansion Analysis"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#EstimateMethod"
@@ -7521,6 +8121,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Relative abundance metric status"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -8178,6 +8784,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Return year"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#YearBasis"
@@ -8228,6 +8840,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Review/QA"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -8275,6 +8893,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Run Coverage"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -8314,6 +8938,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Salmon Enhancement and Hatcheries"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -8551,6 +9181,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Species"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#WSPOutputVariable"
@@ -8606,6 +9242,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Species at Risk and Recovery"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -8637,6 +9279,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Stock Assessment"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -8912,6 +9560,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Timing"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -8951,6 +9605,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Total age dimension"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -9044,6 +9704,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Trap Count"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/EnumerationMethod"
@@ -9089,6 +9755,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Trap Efficiency"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -9138,6 +9810,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Trap Model Analysis"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#EstimateMethod"
@@ -9177,6 +9855,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Type-1, True Abundance, high resolution"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -9220,6 +9904,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Type-2, True Abundance, medium resolution"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#EstimateType"
@@ -9259,6 +9949,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Type-3, Relative Abundance, high resolution"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -9302,6 +9998,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Type-4, Relative Abundance, medium resolution"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#EstimateType"
@@ -9343,6 +10045,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Type-5, Relative Abundance, low resolution"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#EstimateType"
@@ -9382,6 +10090,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Type-6, Presence or Absence"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -9448,6 +10162,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Unranked index quality"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#EstimateType"
@@ -9487,6 +10207,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Upper benchmark"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -9637,6 +10363,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Uptime"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/gcdfo/salmon#DowngradeCriteria"
@@ -9682,6 +10414,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Visibility"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -9731,6 +10469,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Visual Ground Count"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/EnumerationMethod"
@@ -9776,6 +10520,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Visual Snorkel Count"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -9828,6 +10578,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Wild Salmon Policy biological status zone"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -9906,6 +10662,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "WSP output variable"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -10094,6 +10856,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "WSP rapid-status assessment method"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
       {
         "@language": "en",
@@ -10142,6 +10910,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Wild Salmon Policy"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -10194,6 +10968,12 @@
         "@id": "https://w3id.org/gcdfo/salmon"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Wild Salmon Policy"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
@@ -10231,6 +11011,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/gcdfo/salmon"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Year basis"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -11265,6 +12051,12 @@
         "@id": "https://w3id.org/smn"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Catch context"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/MeasurementContext"
@@ -11340,6 +12132,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Enumeration Method"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -11621,6 +12419,12 @@
         "@id": "https://w3id.org/smn"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Hatchery-origin"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/SalmonOrigin"
@@ -11663,6 +12467,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "In-river phase"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -11757,6 +12567,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Life phase"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -11881,6 +12697,12 @@
         "@id": "https://w3id.org/smn"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Mainstem phase"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/LifePhase"
@@ -11917,6 +12739,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Measurement context"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -12055,6 +12883,12 @@
         "@id": "https://w3id.org/smn"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Natural-origin"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/SalmonOrigin"
@@ -12133,6 +12967,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Ocean phase"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#altLabel": [
@@ -12316,6 +13156,12 @@
         "@id": "https://w3id.org/smn"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Run context"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/MeasurementContext"
@@ -12352,6 +13198,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Salmon origin"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -12427,6 +13279,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Spawner stage context"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [
@@ -12620,6 +13478,12 @@
         "@id": "https://w3id.org/smn"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Survival or mortality context"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
         "@id": "https://w3id.org/smn/MeasurementContext"
@@ -12695,6 +13559,12 @@
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Terminal phase"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#broader": [

--- a/docs/gcdfo.owl
+++ b/docs/gcdfo.owl
@@ -694,7 +694,7 @@
         <rdfs:domain rdf:resource="https://w3id.org/smn/Deme"/>
         <rdfs:range rdf:resource="https://w3id.org/smn/Population"/>
         <obo:IAO_0000115 xml:lang="en">Relates a deme to the population it belongs to.</obo:IAO_0000115>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">deme of</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#GeneticsStockCompositionTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme"/>
@@ -708,7 +708,7 @@
         <rdfs:domain rdf:resource="https://w3id.org/smn/Population"/>
         <rdfs:range rdf:resource="https://w3id.org/smn/Deme"/>
         <obo:IAO_0000115 xml:lang="en">Relates a population to one of its constituent demes.</obo:IAO_0000115>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">has deme</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#GeneticsStockCompositionTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme"/>
@@ -736,7 +736,7 @@
         <rdfs:range rdf:resource="https://w3id.org/smn/Population"/>
         <obo:IAO_0000115 xml:lang="en">Relates a Conservation Unit to one of its constituent populations.</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">DFO profile note: within this ontology, `smn:hasPopulation` is primarily used for ConservationUnit-to-Population composition.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">has population</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme"/>
@@ -757,7 +757,7 @@
         <rdfs:range rdf:resource="https://w3id.org/gcdfo/salmon#ConservationUnit"/>
         <obo:IAO_0000115 xml:lang="en">Relates a population to the Conservation Unit it belongs to.</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">DFO profile note: within this ontology, `smn:populationOf` is primarily used for Population-to-ConservationUnit composition.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">population of</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme"/>
@@ -1685,7 +1685,7 @@
     <owl:Class rdf:about="https://w3id.org/smn/Deme">
         <rdfs:subClassOf rdf:resource="http://rs.tdwg.org/dwc/terms/Organism"/>
         <obo:IAO_0000115 xml:lang="en">A local interbreeding group of organisms within a species. In salmon, a deme typically corresponds to a spawning population at a specific site. Demes are the finest biological unit and make up populations.</obo:IAO_0000115>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Deme</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#GeneticsStockCompositionTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
@@ -1701,7 +1701,7 @@
         <obo:IAO_0000115 xml:lang="en">The number of mature salmon that pass through (or escape) fisheries and return to fresh water to spawn.</obo:IAO_0000115>
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2005. Canada&apos;s Policy for Conservation of Wild Pacific Salmon. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/315577.pdf.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/315577.pdf"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Escapement</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#MonitoringFieldWorkTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
@@ -1715,7 +1715,7 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000109"/>
         <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sosa/Result"/>
         <obo:IAO_0000115 xml:lang="en">A measurement or estimate of escapement tied to a stock and a survey event.</obo:IAO_0000115>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Escapement measurement</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#MonitoringFieldWorkTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
@@ -1728,7 +1728,7 @@
     <owl:Class rdf:about="https://w3id.org/smn/EscapementSurveyEvent">
         <rdfs:subClassOf rdf:resource="https://w3id.org/smn/SurveyEvent"/>
         <obo:IAO_0000115 xml:lang="en">A survey event specifically for estimating escapement.</obo:IAO_0000115>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Escapement Survey Event</rdfs:label>
         <skos:prefLabel xml:lang="en">Escapement Survey Event</skos:prefLabel>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#MonitoringFieldWorkTheme"/>
@@ -1744,7 +1744,7 @@
         <obo:IAO_0000115 xml:lang="en">A fishing mortality rate expressed as the proportion of the total return removed by fishing over a specified assessment period.</obo:IAO_0000115>
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. Pacific Salmon - Glossary (Pacific Region). https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Exploitation rate</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
@@ -1758,7 +1758,7 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/smn/LimitReferencePoint"/>
         <obo:IAO_0000115 xml:lang="en">A lower fisheries-management reference point defined for Stock Management Units (SMUs) and related fishery decision frameworks. It may be informed by Conservation Unit (CU) lower biological benchmarks, but is not identical to CU-level lower biological benchmarks used to delineate Wild Salmon Policy biological status zones.</obo:IAO_0000115>
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. (2022). Methodologies and Guidelines for Defining Limit Reference Points for Pacific Salmon. DFO Can. Sci. Advis. Sec. Sci. Advis. Rep. 2022/030. (Erratum: December 2022).</obo:IAO_0000119>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Fisheries Reference Point - Lower</rdfs:label>
         <skos:altLabel xml:lang="en">FRP-L</skos:altLabel>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"/>
@@ -1774,7 +1774,7 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/smn/ReportingOrManagementStratum"/>
         <obo:IAO_0000115 xml:lang="en">A reporting and assessment stratum identifying monitored indicator streams that provide representative indices of spawner abundance for nearby streams.</obo:IAO_0000115>
         <dcterms:source rdf:resource="https://www.salmonexplorer.ca/methods/glossary.html"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Indicator river</rdfs:label>
         <skos:altLabel xml:lang="en">Indicator stream</skos:altLabel>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#MonitoringFieldWorkTheme"/>
@@ -1791,7 +1791,7 @@
         <obo:IAO_0000115 xml:lang="en">A fish stock experiencing serious harm may be depleted to the point where it has impaired productivity or reproductive capacity. As a result, the stock would be less resilient to fishing and could not easily rebuild. Serious harm may be irreversible, or only slowly reversible over the long-term, and can be due to fishing, other human-induced impacts, or natural causes. Under the Precautionary Approach policy and the Fish Stocks Provisions (FSPs), breaching the LRP is a trigger for a rebuilding plan.</obo:IAO_0000115>
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. Introduction to Stock Assessment - Glossary. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Limit reference point</rdfs:label>
         <skos:altLabel xml:lang="en">LRP</skos:altLabel>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"/>
@@ -1809,7 +1809,7 @@
         <obo:IAO_0000119 xml:lang="en">Pestal, G., MacDonald, B.L., Grant, S.C.H., and Holt, C.A. 2023. State of the salmon: rapid status assessment approach for Pacific salmon under Canada&apos;s Wild Salmon Policy. Canadian Technical Report of Fisheries and Aquatic Sciences 3570.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://publications.gc.ca/site/eng/9.928944/publication.html"/>
         <rdfs:comment xml:lang="en">DFO profile note: this ontology applies `smn:MetricBenchmark` in Wild Salmon Policy status-zone workflows.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Metric benchmark</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme"/>
@@ -1822,7 +1822,7 @@
     <owl:Class rdf:about="https://w3id.org/smn/ObservedRateOrAbundance">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000109"/>
         <obo:IAO_0000115 xml:lang="en">A measurement datum representing an empirically observed rate, count, or abundance derived from monitoring or survey data.</obo:IAO_0000115>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Observed rate or abundance</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
@@ -1836,7 +1836,7 @@
         <rdfs:subClassOf rdf:resource="http://rs.tdwg.org/dwc/terms/Organism"/>
         <obo:IAO_0000115 xml:lang="en">A group of organisms of the same species occupying a defined area that interbreed and share a gene pool. In salmon, populations are composed of one or more demes and form the biological basis for Conservation Units.</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">DFO profile note: this ontology applies `smn:Population` in Wild Salmon Policy / Conservation Unit contexts.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Population</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#GeneticsStockCompositionTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
@@ -1853,7 +1853,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. Introduction to Stock Assessment - Glossary. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html"/>
         <rdfs:comment xml:lang="en">DFO profile note: this ontology applies `smn:ReferencePoint` in DFO fisheries-management and assessment workflows.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Reference point</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"/>
@@ -1867,7 +1867,7 @@
     <owl:Class rdf:about="https://w3id.org/smn/ReportingOrManagementStratum">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
         <obo:IAO_0000115 xml:lang="en">An information-defined grouping of fish populations used for reporting, conservation assessment, or management purposes. Examples include Conservation Units (CUs), Stock Management Units (MUs), and Designatable Units (DUs).</obo:IAO_0000115>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Reporting or management stratum</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
@@ -1882,7 +1882,7 @@
         <obo:IAO_0000115 xml:lang="en">An operationally-defined grouping of salmon used for assessment and management purposes. A stock is a management unit or reporting stratum, not a biological organism.</obo:IAO_0000115>
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. Introduction to Stock Assessment - Glossary. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Stock</rdfs:label>
         <skos:altLabel xml:lang="en">Fish stock</skos:altLabel>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"/>
@@ -1899,7 +1899,7 @@
         <obo:IAO_0000115 xml:lang="en">The scientific process of analyzing data to estimate the abundance and productivity of fish stocks in the past, present, and future. It is the backbone of successful science-based fisheries management</obo:IAO_0000115>
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. Introduction to Stock Assessment. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/module-1/09-eng.html.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/module-1/09-eng.html"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Stock assessment</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
     </owl:Class>
@@ -1915,7 +1915,7 @@
         <obo:IAO_0000115 xml:lang="en">A field event that collects information about key fish stocks to track their status, and track progress to implement fishery policies and measures for these stocks.</obo:IAO_0000115>
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. About the Sustainability Survey for Fisheries. https://www.dfo-mpo.gc.ca/reports-rapports/regs/sff-cpd/survey-sondage/about-propos-en.html.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://www.dfo-mpo.gc.ca/reports-rapports/regs/sff-cpd/survey-sondage/about-propos-en.html"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Survey event</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#MonitoringFieldWorkTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
@@ -1928,7 +1928,7 @@
     <owl:Class rdf:about="https://w3id.org/smn/TargetOrLimitRateOrAbundance">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000109"/>
         <obo:IAO_0000115 xml:lang="en">A value specification representing a policy- or model-defined target or limit, such as TAC or UMSY.</obo:IAO_0000115>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Target or limit rate or abundance</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme"/>
@@ -1942,7 +1942,7 @@
     <owl:Class rdf:about="https://w3id.org/smn/TotalExploitationRate">
         <rdfs:subClassOf rdf:resource="https://w3id.org/gcdfo/salmon#ObservedExploitationRate"/>
         <obo:IAO_0000115 xml:lang="en">The overall proportion of the total return of adult salmon removed by all fisheries over a defined period, aggregating across gear or fishery components.</obo:IAO_0000115>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Total exploitation rate</rdfs:label>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme"/>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
@@ -4424,7 +4424,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/CatchContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:broader rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:definition xml:lang="en">Measurement context indicating values refer to fishery catch.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
@@ -4438,7 +4438,7 @@
 
     <owl:NamedIndividual rdf:about="https://w3id.org/smn/EnumerationMethod">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:definition xml:lang="en">A method used to enumerate or count salmon in the field</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EnumerationMethodScheme"/>
         <skos:prefLabel xml:lang="en">Enumeration Method</skos:prefLabel>
@@ -4455,7 +4455,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2018. Review of genetically based targets for enhanced contributions to Canadian Pacific Chinook Salmon populations. DFO Canadian Science Advisory Secretariat Science Advisory Report 2018/001 (Erratum: October 2023).</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://www.dfo-mpo.gc.ca/csas-sccs/Publications/SAR-AS/2018/2018_001-eng.html"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:broader rdf:resource="https://w3id.org/smn/SalmonOrigin"/>
         <skos:definition xml:lang="en">Individuals that were born or reared in a hatchery facility.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/SalmonOriginScheme"/>
@@ -4471,7 +4471,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/InRiverPhase">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:altLabel xml:lang="en">Freshwater phase</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/smn/LifePhase"/>
         <skos:definition xml:lang="en">Freshwater in-river phase (migration and/or residence) outside the marine environment.</skos:definition>
@@ -4486,7 +4486,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/LifePhase">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:definition xml:lang="en">A phase or segment used to stratify salmon measurements by where or when they apply (e.g., ocean phase, terminal phase).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/LifePhaseScheme"/>
         <skos:prefLabel xml:lang="en">Life phase</skos:prefLabel>
@@ -4499,7 +4499,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/LifePhaseScheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:definition xml:lang="en">Controlled vocabulary for life-phase or fishery/migration segment qualifiers used to stratify measurements (e.g., ocean, terminal, mainstem).</skos:definition>
         <skos:hasTopConcept rdf:resource="https://w3id.org/smn/LifePhase"/>
         <skos:prefLabel xml:lang="en">Life phase scheme</skos:prefLabel>
@@ -4512,7 +4512,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/MainstemPhase">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:broader rdf:resource="https://w3id.org/smn/LifePhase"/>
         <skos:definition xml:lang="en">Freshwater mainstem migration phase in a river system (often corresponding to mainstem in-river fisheries or monitoring segments).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/LifePhaseScheme"/>
@@ -4526,7 +4526,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/MeasurementContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:definition xml:lang="en">A context qualifier used to disambiguate the interpretation of a measurement column.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
         <skos:prefLabel xml:lang="en">Measurement context</skos:prefLabel>
@@ -4540,7 +4540,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/MeasurementContextScheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:definition xml:lang="en">Controlled vocabulary for compositional measurement context qualifiers (for example, catch context, run context).</skos:definition>
         <skos:hasTopConcept rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:prefLabel xml:lang="en">Measurement context scheme</skos:prefLabel>
@@ -4556,7 +4556,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2018. Review of genetically based targets for enhanced contributions to Canadian Pacific Chinook Salmon populations. DFO Canadian Science Advisory Secretariat Science Advisory Report 2018/001 (Erratum: October 2023).</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://www.dfo-mpo.gc.ca/csas-sccs/Publications/SAR-AS/2018/2018_001-eng.html"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:broader rdf:resource="https://w3id.org/smn/SalmonOrigin"/>
         <skos:definition xml:lang="en">Individuals that are born and reared in the wild (natural environment).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/SalmonOriginScheme"/>
@@ -4572,7 +4572,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/OceanPhase">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:altLabel xml:lang="en">Marine phase</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/smn/LifePhase"/>
         <skos:definition xml:lang="en">Phase of the salmon life cycle or assessment period occurring in the marine environment.</skos:definition>
@@ -4587,7 +4587,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/RunContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:broader rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:definition xml:lang="en">Measurement context indicating values refer to run size or returning run composition.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
@@ -4601,7 +4601,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/SalmonOrigin">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:definition xml:lang="en">Origin category describing whether salmon are naturally produced, hatchery produced, or mixed-origin.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/SalmonOriginScheme"/>
         <skos:prefLabel xml:lang="en">Salmon origin</skos:prefLabel>
@@ -4615,7 +4615,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/SalmonOriginScheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:definition xml:lang="en">Controlled vocabulary for describing the origin of individual salmon (e.g., natural-origin, hatchery-origin, mixed-origin).</skos:definition>
         <skos:hasTopConcept rdf:resource="https://w3id.org/smn/SalmonOrigin"/>
         <skos:prefLabel xml:lang="en">Salmon Origin Scheme</skos:prefLabel>
@@ -4630,7 +4630,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/SpawnerStageContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:broader rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:definition xml:lang="en">Measurement context indicating values refer to spawners or spawning-stage fish.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
@@ -4644,7 +4644,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/SurvivalOrMortalityContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:broader rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:definition xml:lang="en">Measurement context indicating values represent survival, mortality, or related rates.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
@@ -4658,7 +4658,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/smn/TerminalPhase">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <skos:broader rdf:resource="https://w3id.org/smn/LifePhase"/>
         <skos:definition xml:lang="en">Phase occurring in terminal areas near river mouths or spawning areas (often including terminal fisheries and local migration to spawning sites).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/LifePhaseScheme"/>

--- a/docs/gcdfo.owl
+++ b/docs/gcdfo.owl
@@ -269,6 +269,7 @@
     <!-- https://w3id.org/gcdfo/salmon#theme -->
 
     <owl:AnnotationProperty rdf:about="https://w3id.org/gcdfo/salmon#theme">
+        <obo:IAO_0000115 xml:lang="en">Associates OWL classes and SKOS concepts with high-level thematic concept schemes (e.g., Stock Assessment, GSI, Policy).</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">Associates OWL classes and SKOS concepts with high-level thematic concept schemes (e.g., Stock Assessment, GSI, Policy).</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
         <rdfs:label xml:lang="en">theme</rdfs:label>
@@ -3669,6 +3670,7 @@
         <obo:IAO_0000115 xml:lang="en">Rapid status confidence category indicating that high-quality abundance metrics support the result.</obo:IAO_0000115>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
         <rdfs:label xml:lang="en">High rapid-status confidence</rdfs:label>
+        <skos:definition xml:lang="en">Rapid status confidence category indicating that high-quality abundance metrics support the result.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme"/>
         <skos:prefLabel xml:lang="en">High confidence</skos:prefLabel>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
@@ -3685,6 +3687,7 @@
         <obo:IAO_0000115 xml:lang="en">Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone).</obo:IAO_0000115>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
         <rdfs:label xml:lang="en">Low rapid-status confidence</rdfs:label>
+        <skos:definition xml:lang="en">Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme"/>
         <skos:prefLabel xml:lang="en">Low confidence</skos:prefLabel>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>
@@ -3701,6 +3704,7 @@
         <obo:IAO_0000115 xml:lang="en">Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information.</obo:IAO_0000115>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
         <rdfs:label xml:lang="en">Medium rapid-status confidence</rdfs:label>
+        <skos:definition xml:lang="en">Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme"/>
         <skos:prefLabel xml:lang="en">Medium confidence</skos:prefLabel>
         <theme rdf:resource="https://w3id.org/gcdfo/salmon#StockAssessmentTheme"/>

--- a/docs/gcdfo.owl
+++ b/docs/gcdfo.owl
@@ -1967,6 +1967,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Absolute abundance metric status</rdfs:label>
         <skos:altLabel xml:lang="en">AbsAbdCat</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
         <skos:definition xml:lang="en">Categorical status derived from the absolute abundance metric benchmark ratio.</skos:definition>
@@ -1992,6 +1993,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Abundance data type</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:definition xml:lang="en">A categorical attribute indicating whether an abundance time series is recorded as absolute abundance or as a relative index (used by rapid-status workflows).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
@@ -2013,6 +2015,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Abundance percentile metric</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetric"/>
         <skos:definition xml:lang="en">An abundance percentile metric giving the percentile rank of the current generational average spawner abundance relative to a historical reference distribution.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetricScheme"/>
@@ -2033,6 +2036,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Abundance percentile metric status</rdfs:label>
         <skos:altLabel xml:lang="en">PercentileCat</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
         <skos:definition xml:lang="en">Categorical status derived from abundance percentile metric values.</skos:definition>
@@ -2055,6 +2059,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Helicopter, Fixed Wing Aircraft, Aerial, Drone, UAS, UAV</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Aerial Survey Count</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
         <skos:definition xml:lang="en">Overflights (helicopter, fixed wing, or drone) with documented flight lines, coverage, visibility, and sensor settings. Imagery may be reviewed post-flight.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EnumerationMethodScheme"/>
@@ -2070,6 +2075,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Age1YearClass">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age 1 year class</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValue"/>
         <skos:definition xml:lang="en">Age class value 1 year.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValueScheme"/>
@@ -2085,6 +2091,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Age2YearClass">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age 2 year class</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValue"/>
         <skos:definition xml:lang="en">Age class value 2 years.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValueScheme"/>
@@ -2100,6 +2107,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Age3YearClass">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age 3 year class</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValue"/>
         <skos:definition xml:lang="en">Age class value 3 years.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValueScheme"/>
@@ -2115,6 +2123,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Age4YearClass">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age 4 year class</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValue"/>
         <skos:definition xml:lang="en">Age class value 4 years.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValueScheme"/>
@@ -2130,6 +2139,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Age5YearClass">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age 5 year class</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValue"/>
         <skos:definition xml:lang="en">Age class value 5 years.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValueScheme"/>
@@ -2145,6 +2155,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Age6YearClass">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age 6 year class</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValue"/>
         <skos:definition xml:lang="en">Age class value 6 years.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValueScheme"/>
@@ -2160,6 +2171,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Age7YearClass">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age 7 year class</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValue"/>
         <skos:definition xml:lang="en">Age class value 7 years.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValueScheme"/>
@@ -2175,6 +2187,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#AgeAtMaturityBasis">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age at maturity basis</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeBasis"/>
         <skos:definition xml:lang="en">Age measured at maturity.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeBasisScheme"/>
@@ -2190,6 +2203,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#AgeAtReturnBasis">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age at return basis</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeBasis"/>
         <skos:definition xml:lang="en">Age measured at return migration (adult return timing).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeBasisScheme"/>
@@ -2205,6 +2219,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#AgeAtSamplingBasis">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age at sampling basis</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeBasis"/>
         <skos:definition xml:lang="en">Age measured at the time of sampling or observation.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeBasisScheme"/>
@@ -2220,6 +2235,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#AgeBasis">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age basis</rdfs:label>
         <skos:definition xml:lang="en">The reference event or life-history point that an age value is measured against.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeBasisScheme"/>
         <skos:prefLabel xml:lang="en">Age basis</skos:prefLabel>
@@ -2248,6 +2264,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#AgeClassValue">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age class value</rdfs:label>
         <skos:definition xml:lang="en">An integer-like age class value used as a compositional constraint in salmon measurements.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeClassValueScheme"/>
         <skos:prefLabel xml:lang="en">Age class value</skos:prefLabel>
@@ -2274,6 +2291,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#AgeDimension">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age dimension</rdfs:label>
         <skos:definition xml:lang="en">The age component represented by a value (total age, freshwater years, or ocean years).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeDimensionScheme"/>
         <skos:prefLabel xml:lang="en">Age dimension</skos:prefLabel>
@@ -2300,6 +2318,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#AgeNotation">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Age notation</rdfs:label>
         <skos:definition xml:lang="en">A notation system used to encode salmon age values in stock assessment data.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeNotationScheme"/>
         <skos:prefLabel xml:lang="en">Age notation</skos:prefLabel>
@@ -2332,6 +2351,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. Wild Salmon Policy 2018-2022 Implementation Plan. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Amber zone</rdfs:label>
         <skos:definition xml:lang="en">Amber status implies caution in the management of the Conservation Unit. While a CU in the Amber zone should be at a low risk of loss, there will be a degree of lost production. Decisions about the conservation of CUs in the Amber zone will involve broader consideration of biological, social, and economic issues. </skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#IntegratedStatusOutcomeScheme"/>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#WSPBiologicalStatusZoneScheme"/>
@@ -2348,6 +2368,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#AreaUnderTheCurve">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Area Under the Curve</rdfs:label>
         <skos:altLabel xml:lang="en">AUC</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethod"/>
         <skos:definition xml:lang="en">Integrates serial counts over time using a survey-life parameter; may apply observer efficiency.</skos:definition>
@@ -2381,6 +2402,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Benchmark ratio metric</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetric"/>
         <skos:definition xml:lang="en">A benchmark-ratio metric equal to the ratio of current generational average spawner abundance to a specified benchmark (lower or upper benchmark), where 1.0 indicates equality to that benchmark.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetricScheme"/>
@@ -2416,6 +2438,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 2 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Bypass/Breach Risk</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Bypass or breach risks not monitored and verified negligible</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -2434,6 +2457,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. Pacific Salmon - Glossary (Pacific Region). https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Brood year</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#YearBasis"/>
         <skos:closeMatch rdf:resource="http://purl.dataone.org/odo/SALMON_00000520"/>
         <skos:definition xml:lang="en">The parental year for a group of returning salmon, i.e. the calendar year when the majority of parents of these fish spawned.</skos:definition>
@@ -2466,6 +2490,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Document calibration source years, transferability, diagnostics. Type-2 when calibration robust and applicable; else Type-3.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Calibrated Time Series</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethod"/>
         <skos:definition xml:lang="en">Regression/state-space model calibrated to a Type-1/2 series converts a lower-precision index to abundance.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethodScheme"/>
@@ -2482,6 +2507,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <obo:IAO_0000115 xml:lang="en">The calendar year in which returning salmon are caught in fisheries (as opposed to the brood year in which the cohort was spawned).</obo:IAO_0000115>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Catch year</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#YearBasis"/>
         <skos:definition xml:lang="en">The calendar year in which returning salmon are caught in fisheries (as opposed to the brood year in which the cohort was spawned).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#YearBasisScheme"/>
@@ -2498,6 +2524,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 3 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Classification</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Classification/attribution not documented</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -2522,6 +2549,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Conservation Unit name</rdfs:label>
         <skos:altLabel xml:lang="en">Stock (canonical WSP output column label)</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
         <skos:definition xml:lang="en">Full Conservation Unit name field used in canonical WSP outputs.</skos:definition>
@@ -2542,6 +2570,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 2 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Cross-section Coverage</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Incomplete cross-section coverage</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -2557,6 +2586,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Data, Models, and Provenance</rdfs:label>
         <skos:definition xml:lang="en">Data models, analytical workflows, provenance, quality dimensions, and metadata supporting salmon science.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#ThemeScheme"/>
         <skos:prefLabel xml:lang="en">Data, Models, and Provenance</skos:prefLabel>
@@ -2570,6 +2600,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#DataQualityRatingContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Data quality rating context</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:definition xml:lang="en">Measurement context indicating categorical or ordinal quality ratings.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
@@ -2585,6 +2616,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 3 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Detectability</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Detectability factors not validated</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -2601,6 +2633,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 2 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Device Configuration</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Device not within operational specifications</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -2617,6 +2650,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Downgrades Type 1/2 by one level</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Documentation</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Missing SIL/SEN logs or QA/methods report</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -2632,6 +2666,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#DowngradeCriteria">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Downgrade Criteria</rdfs:label>
         <skos:definition xml:lang="en">Criteria that may result in downgrading an escapement estimate type classification</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
         <skos:prefLabel xml:lang="en">Downgrade Criteria</skos:prefLabel>
@@ -2660,6 +2695,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 4 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Effort Standardization</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Effort not standardized</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -2676,6 +2712,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Electrofishing, Electroshocking</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Electrofishing Count</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
         <skos:definition xml:lang="en">Effort-standardized electrofishing passes used to generate catch-per-unit-effort (CPUE) indices.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EnumerationMethodScheme"/>
@@ -2705,6 +2742,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 2 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Environmental Conditions</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Environmental conditions outside specifications</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -2720,6 +2758,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#EstimateMethod">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Estimate Method</rdfs:label>
         <skos:definition xml:lang="en">A method used to analyze and estimate salmon abundance from enumeration data</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethodScheme"/>
         <skos:prefLabel xml:lang="en">Estimate Method</skos:prefLabel>
@@ -2747,6 +2786,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#EstimateType">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Estimate Type</rdfs:label>
         <skos:definition xml:lang="en">Classification of escapement estimate quality based on Hyatt 1997 framework</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateTypeScheme"/>
         <skos:prefLabel xml:lang="en">Estimate Type</skos:prefLabel>
@@ -2775,6 +2815,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://www.pac.dfo-mpo.gc.ca/fm-gp/fraser/docs/archiv-reports-rapports/indigenous-autochtone/2010FrasRvrChkInformDoc.htm"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">European age notation</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeNotation"/>
         <skos:definition xml:lang="en">Salmon age notation that records freshwater years followed by ocean years (for example, 1.2).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeNotationScheme"/>
@@ -2794,6 +2835,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2021. Marine Survival Forecast of Southern British Columbia Coho (describes applying expansion factors to PIT detections to estimate total escapement).</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/Library/40978680.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Expansion factor</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#ExpansionMathematicalOperations"/>
         <skos:definition xml:lang="en">A multiplicative factor used to expand observed counts or detections from a sampled subset (e.g., indicator sites, PIT detections) to an estimated total abundance or escapement.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethodScheme"/>
@@ -2810,6 +2852,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Lake Expansion, Redd Expansion, Peak×Factor, (Peak+CumDead)×Factor, Addition/Subtraction, Multiplication/Division. Inherits base method&apos;s Type; weak provenance = downgrade one Type.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Expansion/Mathematical Operations</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethod"/>
         <skos:definition xml:lang="en">Applies expansion factors or arithmetic transforms to a base count/index.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethodScheme"/>
@@ -2825,6 +2868,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#FishStockProvisions">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Fish Stocks Provisions</rdfs:label>
         <skos:altLabel xml:lang="en">FSP</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#PolicyFramework"/>
         <skos:definition xml:lang="en">Legal provisions in Canada&apos;s Fisheries Act and regulations related to maintaining and rebuilding fish stocks, including obligations triggered when reference points are breached.</skos:definition>
@@ -2842,6 +2886,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#FisheriesManagementTheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Fisheries Management</rdfs:label>
         <skos:definition xml:lang="en">Fishery openings, harvest control rules, catch/effort measures, and exploitation monitoring for salmon fisheries.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#ThemeScheme"/>
         <skos:prefLabel xml:lang="en">Fisheries Management</skos:prefLabel>
@@ -2856,6 +2901,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Electronic/Optical counter, Resistivity Counter, Video/Camera counter</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Fixed Site Census (Electronic)</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
         <skos:definition xml:lang="en">Automated counting at a constrained opening using electronic/optical counters, resistivity counters, or video/camera systems. QA review of automated events, cross-section coverage, and uptime/coverage are documented.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EnumerationMethodScheme"/>
@@ -2872,6 +2918,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Fence, Weir, Fixed Site Census (manual)</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Fixed Site Census (Manual)</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
         <skos:definition xml:lang="en">Salmon are guided through a controlled opening in a fence/weir where trained observers visually tally each passage event on a continuous or daily schedule. Counting chambers/windows and SIL/SEN daily logs document coverage; bypass routes are monitored and closed where possible.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EnumerationMethodScheme"/>
@@ -2887,6 +2934,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#FixedStationTally">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Fixed‑Station Tally</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethod"/>
         <skos:definition xml:lang="en">Seasonal total = roll‑up of daily/continuous counts from a fixed (non‑sonar) station; simple arithmetic with documented coverage.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethodScheme"/>
@@ -2902,6 +2950,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#FreshwaterAgeDimension">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Freshwater age dimension</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeDimension"/>
         <skos:definition xml:lang="en">Age value represents years spent in freshwater.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeDimensionScheme"/>
@@ -2920,6 +2969,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Generational average abundance</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetric"/>
         <skos:definition xml:lang="en">The generational average of spawner abundance, calculated as a geometric mean across the number of years corresponding to the most common age at return (generation length), optionally after smoothing depending on CU group.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetricScheme"/>
@@ -2939,6 +2989,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#GeneticsStockCompositionTheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Genetics and Stock Composition</rdfs:label>
         <skos:definition xml:lang="en">Genetic markers, assays, and analyses used to infer stock composition, parentage, and population structure.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#ThemeScheme"/>
         <skos:prefLabel xml:lang="en">Genetics and Stock Composition</skos:prefLabel>
@@ -2953,6 +3004,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://www.pac.dfo-mpo.gc.ca/fm-gp/fraser/docs/archiv-reports-rapports/indigenous-autochtone/2010FrasRvrChkInformDoc.htm"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Gilbert-Rich age notation</rdfs:label>
         <skos:altLabel xml:lang="en">GR age notation</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeNotation"/>
         <skos:definition xml:lang="en">Salmon age notation where total age is annotated with freshwater years as a subscript-like suffix (for example, 4_2 for total age 4 with 2 freshwater years).</skos:definition>
@@ -2974,6 +3026,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. Wild Salmon Policy 2018-2022 Implementation Plan. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Green zone</rdfs:label>
         <skos:definition xml:lang="en">Social and economic considerations will tend to be the primary drivers for the management of Conservation Units in the Green zone, though ecosystem or other non-consumptive use values could also be considered.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#IntegratedStatusOutcomeScheme"/>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#WSPBiologicalStatusZoneScheme"/>
@@ -2990,6 +3043,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#HabitatEcosystemClimateTheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Habitat, Ecosystem, and Climate Pressures</rdfs:label>
         <skos:definition xml:lang="en">Habitat attributes, ecosystem conditions, and climate or environmental stressors affecting salmon.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#ThemeScheme"/>
         <skos:prefLabel xml:lang="en">Habitat, Ecosystem, and Climate Pressures</skos:prefLabel>
@@ -3004,6 +3058,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Hydroacoustics, Sonar (ARIS/DIDSON). Not Type-1 under Hyatt; interpolation and classification error are central downgrades.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Hydroacoustic Modelling</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethod"/>
         <skos:definition xml:lang="en">Model pipeline converts sonar detections to passage totals; sets range/angle/blind zones; species/size attribution rules documented.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethodScheme"/>
@@ -3020,6 +3075,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Sonar-ARIS, Sonar-DIDSON, Hydroacoustic</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Hydroacoustic Sonar Count</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
         <skos:definition xml:lang="en">Sonar detections (ARIS, DIDSON, or other hydroacoustic systems) with documented coverage, visibility/noise conditions, and uptime. Raw detections require processing through a modelling/classification pipeline.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EnumerationMethodScheme"/>
@@ -3036,6 +3092,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 2 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Infill Method</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Interpolation used for missing data; defensibility must be documented</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -3054,6 +3111,7 @@
         <obo:IAO_0000119 xml:lang="en">Approved WSP statuses output uses IntStatusRaw value AmberGreen and IntStatusRaw_Short code AG.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Amber/Green integrated status</rdfs:label>
         <skos:definition xml:lang="en">Blended integrated status outcome between Amber and Green used when expert evidence supports an intermediate boundary outcome.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#IntegratedStatusOutcomeScheme"/>
         <skos:notation>AG</skos:notation>
@@ -3073,6 +3131,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Integrated status (binary red/not-red)</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
         <skos:altLabel xml:lang="en">IntStatus2</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
@@ -3095,6 +3154,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Collapsed integrated status code</rdfs:label>
         <skos:altLabel xml:lang="en">IntStatus_Short</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
         <skos:definition xml:lang="en">Short code representation of the three-category collapsed integrated status field.</skos:definition>
@@ -3118,6 +3178,7 @@
         <obo:IAO_0000119 xml:lang="en">WSP integrated-status documentation defines data deficient outcomes where status cannot be assigned because information is insufficient.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Data deficient integrated status</rdfs:label>
         <skos:definition xml:lang="en">Integrated status outcome indicating insufficient information to assign a biological zone outcome.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#IntegratedStatusOutcomeScheme"/>
         <skos:notation>DD</skos:notation>
@@ -3135,6 +3196,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Integrated status (5-category legacy alias)</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
         <skos:altLabel xml:lang="en">IntStatus5</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
@@ -3157,6 +3219,7 @@
         <rdf:type rdf:resource="https://w3id.org/gcdfo/salmon#IntegratedStatusOutcome"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Not-red integrated status</rdfs:label>
         <skos:definition xml:lang="en">Binary integrated-status outcome indicating the Conservation Unit is not in Red status after binary collapse of integrated outcomes.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#IntegratedStatusOutcomeScheme"/>
         <skos:notation>NotRed</skos:notation>
@@ -3197,6 +3260,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Integrated status (raw)</rdfs:label>
         <skos:altLabel xml:lang="en">IntStatusRaw</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
         <skos:definition xml:lang="en">Expert-assigned integrated WSP status outcome prior to collapsed-category derivations.</skos:definition>
@@ -3219,6 +3283,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Raw integrated status code</rdfs:label>
         <skos:altLabel xml:lang="en">IntStatusRaw_Short</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
         <skos:definition xml:lang="en">Short code representation of IntegratedStatusRaw values.</skos:definition>
@@ -3242,6 +3307,7 @@
         <obo:IAO_0000119 xml:lang="en">Approved WSP statuses output uses IntStatusRaw value RedAmber and IntStatusRaw_Short code RA.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Red/Amber integrated status</rdfs:label>
         <skos:definition xml:lang="en">Blended integrated status outcome between Red and Amber used when expert evidence supports an intermediate boundary outcome.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#IntegratedStatusOutcomeScheme"/>
         <skos:notation>RA</skos:notation>
@@ -3261,6 +3327,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Integrated status (3-category collapsed)</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
         <skos:altLabel xml:lang="en">IntStatus3</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
@@ -3285,6 +3352,7 @@
         <obo:IAO_0000119 xml:lang="en">Approved WSP statuses output uses UD for undetermined integrated-status outcomes.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Undetermined integrated status</rdfs:label>
         <skos:altLabel xml:lang="en">to be determined</skos:altLabel>
         <skos:definition xml:lang="en">Integrated status outcome used when an assessment is unresolved or pending completion.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#IntegratedStatusOutcomeScheme"/>
@@ -3306,6 +3374,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Long-term trend metric</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetric"/>
         <skos:definition xml:lang="en">A long-term trend metric comparing the current generational average (geometric mean) spawner abundance to the long-term average (geometric mean) spawner abundance for an assessed time series.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetricScheme"/>
@@ -3326,6 +3395,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Long-term trend metric status</rdfs:label>
         <skos:altLabel xml:lang="en">LongTrendCat</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
         <skos:definition xml:lang="en">Categorical status derived from the long-term trend metric using WSP status-zone thresholds.</skos:definition>
@@ -3347,6 +3417,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#LowerBenchmark">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Lower benchmark</rdfs:label>
         <skos:definition xml:lang="en">A lower-threshold benchmark value, typically delineating the boundary between Red and Amber status zones.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#BenchmarkLevelScheme"/>
         <skos:prefLabel xml:lang="en">Lower benchmark</skos:prefLabel>
@@ -3361,6 +3432,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#ManagementReferenceContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Management reference context</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:definition xml:lang="en">Measurement context indicating values are management benchmarks or reference-oriented metrics.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
@@ -3377,6 +3449,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Petersen, Jolly-Seber, Open model, Bayesian MR. Store uncertainty (e.g., CV) when available; note tag loss/recovery protocols.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Mark-Recapture Analysis</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethod"/>
         <skos:definition xml:lang="en">Capture-recapture estimators (Petersen, Jolly-Seber, open/Bayesian models) applied to field marks/recoveries.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethodScheme"/>
@@ -3393,6 +3466,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 3 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Mark-Recapture Assumptions</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">MR assumptions not evaluated</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -3409,6 +3483,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Tag Recovery</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Mark-Recapture Field Program</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
         <skos:definition xml:lang="en">Field program involving marking and subsequent recapture/recovery of tagged fish with documented assumptions and recovery coverage.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EnumerationMethodScheme"/>
@@ -3425,6 +3500,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 5 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Method Unknown/Inconsistent</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Survey/analytical methods not adequately identified/consistent</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -3440,6 +3516,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#MonitoringFieldWorkTheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Monitoring and Field Work</rdfs:label>
         <skos:definition xml:lang="en">Field observations, sampling protocols, survey events, gear, and measurement methods used to collect salmon data.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#ThemeScheme"/>
         <skos:prefLabel xml:lang="en">Monitoring and Field Work</skos:prefLabel>
@@ -3454,6 +3531,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 4 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Number of Visits</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Insufficient number of survey visits</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -3469,6 +3547,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#OceanAgeDimension">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Ocean age dimension</rdfs:label>
         <skos:altLabel xml:lang="en">Marine age dimension</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeDimension"/>
         <skos:definition xml:lang="en">Age value represents years spent in the marine environment.</skos:definition>
@@ -3485,6 +3564,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Peak Live, Peak Live + Dead, Peak + Cumulative Dead, Cumulative New</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Peak Count Analysis</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethod"/>
         <skos:definition xml:lang="en">Uses the peak survey (live ± dead variants) as the season estimate/index.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethodScheme"/>
@@ -3504,6 +3584,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Percent change metric</rdfs:label>
         <skos:altLabel xml:lang="en">Rapid-status percent change metric</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetric"/>
         <skos:definition xml:lang="en">A short-term trend metric quantifying the percent (linear) change in spawner abundance over the most recent three generations.</skos:definition>
@@ -3525,6 +3606,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Percent change metric status</rdfs:label>
         <skos:altLabel xml:lang="en">PercChangeCat</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
         <skos:definition xml:lang="en">Categorical status derived from the percent-change metric using WSP status-zone thresholds.</skos:definition>
@@ -3546,6 +3628,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#PolicyFramework">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Policy framework</rdfs:label>
         <skos:definition xml:lang="en">A policy, legal, or governance framework that defines how salmon status metrics, benchmarks, or reference points are set and interpreted.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#PolicyFrameworkScheme"/>
         <skos:prefLabel xml:lang="en">Policy framework</skos:prefLabel>
@@ -3576,6 +3659,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Policy, Governance, and Organizational Structure</rdfs:label>
         <skos:definition xml:lang="en">DFO policy frameworks, governance, regulations, and organizational structure relevant to salmon management.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#ThemeScheme"/>
         <skos:prefLabel xml:lang="en">Policy, Governance, and Organizational Structure</skos:prefLabel>
@@ -3589,6 +3673,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#PrecautionaryApproach">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Precautionary Approach</rdfs:label>
         <skos:altLabel xml:lang="en">PA</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#PolicyFramework"/>
         <skos:definition xml:lang="en">DFO policy framework for applying precaution in fisheries decision-making, including use of reference points and stock status zones.</skos:definition>
@@ -3607,6 +3692,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Downgrades by one level</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Precision/Accuracy</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Precision/accuracy weaker than expected for type</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -3626,6 +3712,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Probability of decline below lower benchmark metric</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetric"/>
         <skos:definition xml:lang="en">A probability metric estimating the risk that spawner abundance will be below the lower benchmark, given uncertainty in benchmark estimates and/or abundance estimates, for a defined forecast or assessment horizon.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetricScheme"/>
@@ -3646,6 +3733,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Probability-of-decline-below-lower-benchmark metric status</rdfs:label>
         <skos:altLabel xml:lang="en">ProbDeclBelowLBMCat</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
         <skos:definition xml:lang="en">Categorical status derived from the probability-of-decline-below-lower-benchmark metric.</skos:definition>
@@ -3669,7 +3757,8 @@
         <rdf:type rdf:resource="https://w3id.org/gcdfo/salmon#ConfidenceCategory"/>
         <obo:IAO_0000115 xml:lang="en">Rapid status confidence category indicating that high-quality abundance metrics support the result.</obo:IAO_0000115>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
-        <rdfs:label xml:lang="en">High rapid-status confidence</rdfs:label>
+        <rdfs:label xml:lang="en">High confidence</rdfs:label>
+        <skos:altLabel xml:lang="en">High rapid-status confidence</skos:altLabel>
         <skos:definition xml:lang="en">Rapid status confidence category indicating that high-quality abundance metrics support the result.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme"/>
         <skos:prefLabel xml:lang="en">High confidence</skos:prefLabel>
@@ -3686,7 +3775,8 @@
         <rdf:type rdf:resource="https://w3id.org/gcdfo/salmon#ConfidenceCategory"/>
         <obo:IAO_0000115 xml:lang="en">Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone).</obo:IAO_0000115>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
-        <rdfs:label xml:lang="en">Low rapid-status confidence</rdfs:label>
+        <rdfs:label xml:lang="en">Low confidence</rdfs:label>
+        <skos:altLabel xml:lang="en">Low rapid-status confidence</skos:altLabel>
         <skos:definition xml:lang="en">Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme"/>
         <skos:prefLabel xml:lang="en">Low confidence</skos:prefLabel>
@@ -3703,7 +3793,8 @@
         <rdf:type rdf:resource="https://w3id.org/gcdfo/salmon#ConfidenceCategory"/>
         <obo:IAO_0000115 xml:lang="en">Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information.</obo:IAO_0000115>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
-        <rdfs:label xml:lang="en">Medium rapid-status confidence</rdfs:label>
+        <rdfs:label xml:lang="en">Medium confidence</rdfs:label>
+        <skos:altLabel xml:lang="en">Medium rapid-status confidence</skos:altLabel>
         <skos:definition xml:lang="en">Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme"/>
         <skos:prefLabel xml:lang="en">Medium confidence</skos:prefLabel>
@@ -3733,6 +3824,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <usedProcedure rdf:resource="https://w3id.org/gcdfo/salmon#WSPRapidStatusAssessmentMethod"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Rapid status metric</rdfs:label>
         <skos:definition xml:lang="en">A compound variable concept representing a metric used by WSP rapid-status workflows.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetricScheme"/>
         <skos:prefLabel xml:lang="en">Rapid status metric</skos:prefLabel>
@@ -3768,6 +3860,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Rapid status score metric</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetric"/>
         <skos:definition xml:lang="en">A numeric score produced by a rapid-status algorithm used to represent an ordered status outcome and/or decision-rule position.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusMetricScheme"/>
@@ -3788,6 +3881,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 3 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Reach Coverage</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Insufficient reach coverage</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -3803,6 +3897,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#RecruitStageContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Recruit stage context</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:definition xml:lang="en">Measurement context indicating values refer to recruits.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
@@ -3821,6 +3916,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. Wild Salmon Policy 2018-2022 Implementation Plan. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Red zone</rdfs:label>
         <skos:definition xml:lang="en">A Conservation Unit in the Red zone is undesirable because of the risk of extirpation, and the loss of ecological benefits and salmon production. Changes in status will trigger management actions that will vary depending on species, geographic regions, and cause of the decline.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#IntegratedStatusOutcomeScheme"/>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#WSPBiologicalStatusZoneScheme"/>
@@ -3838,6 +3934,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Redd Counts</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Redd Count</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
         <skos:definition xml:lang="en">Redd counts with documentation of detectability, timing, and reach coverage. Conversion to spawner estimates requires spawners-per-redd factors handled in analysis.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EnumerationMethodScheme"/>
@@ -3854,6 +3951,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Requires validated spawners-per-redd factor and documentation of detectability assumptions.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Redd Expansion Analysis</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethod"/>
         <skos:definition xml:lang="en">Converts redd counts to spawner estimates using spawners-per-redd expansion factors.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethodScheme"/>
@@ -3870,6 +3968,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Relative abundance metric status</rdfs:label>
         <skos:altLabel xml:lang="en">RelAbdCat</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
         <skos:definition xml:lang="en">Categorical status derived from the relative abundance metric benchmark ratio.</skos:definition>
@@ -3894,6 +3993,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. Pacific Salmon Glossary (Pacific Region web page).</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Return year</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#YearBasis"/>
         <skos:definition xml:lang="en">The calendar year in which adult salmon return from the ocean to freshwater systems (a year basis used to contextualize run/return-related measurements).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#YearBasisScheme"/>
@@ -3911,6 +4011,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 2 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Review/QA</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Insufficient QA review of automated events</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -3927,6 +4028,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 2 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Run Coverage</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Run-window coverage &lt; 95% of season days</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -3942,6 +4044,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#SalmonEnhancementHatcheriesTheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Salmon Enhancement and Hatcheries</rdfs:label>
         <skos:definition xml:lang="en">Hatchery production, broodstock management, releases, and enhancement program practices for salmon.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#ThemeScheme"/>
         <skos:prefLabel xml:lang="en">Salmon Enhancement and Hatcheries</skos:prefLabel>
@@ -3956,6 +4059,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <dcterms:source rdf:resource="https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Species</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariable"/>
         <skos:definition xml:lang="en">Species identity field used in canonical WSP outputs.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariableScheme"/>
@@ -3974,6 +4078,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#SpeciesAtRiskRecoveryTheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Species at Risk and Recovery</rdfs:label>
         <skos:definition xml:lang="en">COSEWIC/SARA recovery planning, critical habitat, threats, and status assessments for species of conservation concern.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#ThemeScheme"/>
         <skos:prefLabel xml:lang="en">Species at Risk and Recovery</skos:prefLabel>
@@ -3987,6 +4092,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#StockAssessmentTheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Stock Assessment</rdfs:label>
         <skos:definition xml:lang="en">Stock assessment models, benchmarks, status determinations, and performance metrics for salmon units.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#ThemeScheme"/>
         <skos:prefLabel xml:lang="en">Stock Assessment</skos:prefLabel>
@@ -4030,6 +4136,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 3 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Timing</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Poor timing of surveys</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -4045,6 +4152,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#TotalAgeDimension">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Total age dimension</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#AgeDimension"/>
         <skos:definition xml:lang="en">Age value represents total age in years.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#AgeDimensionScheme"/>
@@ -4060,6 +4168,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Trap, Hatchery Passage Counting</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Trap Count</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
         <skos:definition xml:lang="en">Trap-based counts from non-spanning traps with documented emptying schedule, efficiency measurements, and coverage information.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EnumerationMethodScheme"/>
@@ -4076,6 +4185,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 3 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Trap Efficiency</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Trap efficiency not measured/validated</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -4092,6 +4202,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Requires documented trap efficiency measurements and cross-section coverage factors.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Trap Model Analysis</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethod"/>
         <skos:definition xml:lang="en">Trap-based counts adjusted with efficiency/coverage models to estimate total passage.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethodScheme"/>
@@ -4107,6 +4218,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Type1">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Type-1, True Abundance, high resolution</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateType"/>
         <skos:definition xml:lang="en">Total, seasonal counts through fence or fishway; virtually no bypass. Simple, often single step analysis. Reliable resolution of between year differences &gt;10% (in absolute units).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateTypeScheme"/>
@@ -4122,6 +4234,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Type2">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Type-2, True Abundance, medium resolution</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateType"/>
         <skos:definition xml:lang="en">Indirect estimate of total spawner abundance with qualified accuracy and known precision (i.e., a variance estimate—an explicit quantitative measure of uncertainty around the estimate). Derived from high-effort, standardized methods (e.g., mark-recapture, serial counts for area under the curve) with documented analytical conversions (including interpolation/calibration as needed). Reported in absolute units (estimate ± variance). Reliable resolution of between-year differences &gt;25% (in absolute units).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateTypeScheme"/>
@@ -4137,6 +4250,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Type3">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Type-3, Relative Abundance, high resolution</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateType"/>
         <skos:definition xml:lang="en">Relative abundance index (i.e., not an absolute count) derived from moderate to high effort surveys (typically 3 or more site visits) using standardized methods applied consistently between and within years (e.g., equal-effort surveys executed by walk, swim, overflight). Accuracy and precision are not fully quantified (i.e., no explicit variance estimate), but are assumed stable enough for within-series comparisons. Reliable resolution of between-year differences &gt;25% (in relative units).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateTypeScheme"/>
@@ -4152,6 +4266,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Type4">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Type-4, Relative Abundance, medium resolution</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateType"/>
         <skos:definition xml:lang="en">Low to moderate effort (1-4 trips), known survey method. Simple analysis by known methods. Reliable resolution of between year differences &gt;200% (in relative units).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateTypeScheme"/>
@@ -4167,6 +4282,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Type5">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Type-5, Relative Abundance, low resolution</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateType"/>
         <skos:definition xml:lang="en">Low effort (e.g. 1 trip), use of vaguely defined, inconsistent or poorly executed methods. Unknown to ill defined; inconsistent or poorly executed. Uncertain numeric comparisons, but high reliability for presence or absence.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateTypeScheme"/>
@@ -4182,6 +4298,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#Type6">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Type-6, Presence or Absence</rdfs:label>
         <skos:altLabel xml:lang="en">Presence/Not Detected</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateType"/>
         <skos:definition xml:lang="en">Non-numeric, year-specific record of presence/not detected (i.e., present/absent without estimating a count), tied to an explicit time and location, with reliable species identification. Underlying field methods may be highly variable; analysis is not required.</skos:definition>
@@ -4201,6 +4318,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2020. 2020 summary of abundance data for Chinook salmon (Oncorhynchus tshawytscha) in southern British Columbia, Canada (nuSEDS Estimate Classification includes &apos;Unknown: no quality rating&apos;).</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/Library/40890041.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Unranked index quality</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateType"/>
         <skos:definition xml:lang="en">A data quality category indicating that no spawner-abundance estimate classification / index quality rating was assigned for the record (i.e., an &apos;Unknown&apos; estimate classification with no quality rating).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EstimateTypeScheme"/>
@@ -4216,6 +4334,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#UpperBenchmark">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Upper benchmark</rdfs:label>
         <skos:definition xml:lang="en">An upper-threshold benchmark value, typically delineating the boundary between Amber and Green status zones.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#BenchmarkLevelScheme"/>
         <skos:prefLabel xml:lang="en">Upper benchmark</skos:prefLabel>
@@ -4231,6 +4350,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 2 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Uptime</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Counting/device uptime &lt; 95% (or &lt;90% with interpolation)</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -4247,6 +4367,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Limits to Type 3 maximum</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Visibility</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteria"/>
         <skos:definition xml:lang="en">Poor visibility conditions</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#DowngradeCriteriaScheme"/>
@@ -4263,6 +4384,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Stream Walk, Ground count, Bank Walk</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Visual Ground Count</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
         <skos:definition xml:lang="en">Visual surveys conducted by stream/bank walk with documented visit schedule, reach coverage, timing, and visibility conditions.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EnumerationMethodScheme"/>
@@ -4279,6 +4401,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">Legacy methods: Snorkel, Snorkel Swim</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Visual Snorkel Count</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
         <skos:definition xml:lang="en">Two or more trained snorkelers conduct standardized passes within defined segments, tallying live/dead by species. Field forms capture visibility class, segment boundaries, and repeat-visit schedule; counts are aggregated across observers/passes.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EnumerationMethodScheme"/>
@@ -4317,6 +4440,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#WSPOutputVariable">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">WSP output variable</rdfs:label>
         <skos:definition xml:lang="en">A canonical variable field used in approved Wild Salmon Policy output tables.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#WSPOutputVariableScheme"/>
         <skos:prefLabel xml:lang="en">WSP output variable</skos:prefLabel>
@@ -4349,6 +4473,7 @@
         <obo:IAO_0000119 xml:lang="en">Pestal, G., MacDonald, B.L., Grant, S.C.H., and Holt, C.A. 2023. State of the salmon: rapid status assessment approach for Pacific salmon under Canada&apos;s Wild Salmon Policy. Canadian Technical Report of Fisheries and Aquatic Sciences 3570.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://publications.gc.ca/site/eng/9.928944/publication.html"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">WSP rapid-status assessment method</rdfs:label>
         <skos:altLabel xml:lang="en">WSP rapid status method</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#EstimateMethod"/>
         <skos:definition xml:lang="en">The analytical method used to produce rapid-status metrics under the Wild Salmon Policy rapid-status approach.</skos:definition>
@@ -4366,6 +4491,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#WildSalmonPolicy">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Wild Salmon Policy</rdfs:label>
         <skos:altLabel xml:lang="en">WSP</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/gcdfo/salmon#PolicyFramework"/>
         <skos:definition xml:lang="en">Canada&apos;s Wild Salmon Policy framework for conserving and managing wild Pacific salmon, including integrated status assessments and biological benchmarks for Conservation Units.</skos:definition>
@@ -4383,6 +4509,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Wild Salmon Policy</rdfs:label>
         <skos:definition xml:lang="en">Conservation Unit based stock assessment methods, metrics, and metadata</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#ThemeScheme"/>
         <skos:prefLabel xml:lang="en">Wild Salmon Policy</skos:prefLabel>
@@ -4397,6 +4524,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <obo:IAO_0000115 xml:lang="en">A year-based temporal reference used to contextualize measurements or rates (e.g., brood year, catch year, or return year).</obo:IAO_0000115>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Year basis</rdfs:label>
         <skos:definition xml:lang="en">A year-based temporal reference used to contextualize measurements or rates (e.g., brood year, catch year, or return year).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#YearBasisScheme"/>
         <skos:prefLabel xml:lang="en">Year basis</skos:prefLabel>
@@ -4425,6 +4553,7 @@
     <rdf:Description rdf:about="https://w3id.org/smn/CatchContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Catch context</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:definition xml:lang="en">Measurement context indicating values refer to fishery catch.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
@@ -4439,6 +4568,7 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/smn/EnumerationMethod">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Enumeration Method</rdfs:label>
         <skos:definition xml:lang="en">A method used to enumerate or count salmon in the field</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#EnumerationMethodScheme"/>
         <skos:prefLabel xml:lang="en">Enumeration Method</skos:prefLabel>
@@ -4456,6 +4586,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2018. Review of genetically based targets for enhanced contributions to Canadian Pacific Chinook Salmon populations. DFO Canadian Science Advisory Secretariat Science Advisory Report 2018/001 (Erratum: October 2023).</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://www.dfo-mpo.gc.ca/csas-sccs/Publications/SAR-AS/2018/2018_001-eng.html"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Hatchery-origin</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/SalmonOrigin"/>
         <skos:definition xml:lang="en">Individuals that were born or reared in a hatchery facility.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/SalmonOriginScheme"/>
@@ -4472,6 +4603,7 @@
     <rdf:Description rdf:about="https://w3id.org/smn/InRiverPhase">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">In-river phase</rdfs:label>
         <skos:altLabel xml:lang="en">Freshwater phase</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/smn/LifePhase"/>
         <skos:definition xml:lang="en">Freshwater in-river phase (migration and/or residence) outside the marine environment.</skos:definition>
@@ -4487,6 +4619,7 @@
     <rdf:Description rdf:about="https://w3id.org/smn/LifePhase">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Life phase</rdfs:label>
         <skos:definition xml:lang="en">A phase or segment used to stratify salmon measurements by where or when they apply (e.g., ocean phase, terminal phase).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/LifePhaseScheme"/>
         <skos:prefLabel xml:lang="en">Life phase</skos:prefLabel>
@@ -4513,6 +4646,7 @@
     <rdf:Description rdf:about="https://w3id.org/smn/MainstemPhase">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Mainstem phase</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/LifePhase"/>
         <skos:definition xml:lang="en">Freshwater mainstem migration phase in a river system (often corresponding to mainstem in-river fisheries or monitoring segments).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/LifePhaseScheme"/>
@@ -4527,6 +4661,7 @@
     <rdf:Description rdf:about="https://w3id.org/smn/MeasurementContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Measurement context</rdfs:label>
         <skos:definition xml:lang="en">A context qualifier used to disambiguate the interpretation of a measurement column.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
         <skos:prefLabel xml:lang="en">Measurement context</skos:prefLabel>
@@ -4557,6 +4692,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. 2018. Review of genetically based targets for enhanced contributions to Canadian Pacific Chinook Salmon populations. DFO Canadian Science Advisory Secretariat Science Advisory Report 2018/001 (Erratum: October 2023).</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://www.dfo-mpo.gc.ca/csas-sccs/Publications/SAR-AS/2018/2018_001-eng.html"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Natural-origin</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/SalmonOrigin"/>
         <skos:definition xml:lang="en">Individuals that are born and reared in the wild (natural environment).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/SalmonOriginScheme"/>
@@ -4573,6 +4709,7 @@
     <rdf:Description rdf:about="https://w3id.org/smn/OceanPhase">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Ocean phase</rdfs:label>
         <skos:altLabel xml:lang="en">Marine phase</skos:altLabel>
         <skos:broader rdf:resource="https://w3id.org/smn/LifePhase"/>
         <skos:definition xml:lang="en">Phase of the salmon life cycle or assessment period occurring in the marine environment.</skos:definition>
@@ -4588,6 +4725,7 @@
     <rdf:Description rdf:about="https://w3id.org/smn/RunContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Run context</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:definition xml:lang="en">Measurement context indicating values refer to run size or returning run composition.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
@@ -4602,6 +4740,7 @@
     <rdf:Description rdf:about="https://w3id.org/smn/SalmonOrigin">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Salmon origin</rdfs:label>
         <skos:definition xml:lang="en">Origin category describing whether salmon are naturally produced, hatchery produced, or mixed-origin.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/SalmonOriginScheme"/>
         <skos:prefLabel xml:lang="en">Salmon origin</skos:prefLabel>
@@ -4631,6 +4770,7 @@
     <rdf:Description rdf:about="https://w3id.org/smn/SpawnerStageContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Spawner stage context</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:definition xml:lang="en">Measurement context indicating values refer to spawners or spawning-stage fish.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
@@ -4645,6 +4785,7 @@
     <rdf:Description rdf:about="https://w3id.org/smn/SurvivalOrMortalityContext">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Survival or mortality context</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:definition xml:lang="en">Measurement context indicating values represent survival, mortality, or related rates.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/MeasurementContextScheme"/>
@@ -4659,6 +4800,7 @@
     <rdf:Description rdf:about="https://w3id.org/smn/TerminalPhase">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <rdfs:label xml:lang="en">Terminal phase</rdfs:label>
         <skos:broader rdf:resource="https://w3id.org/smn/LifePhase"/>
         <skos:definition xml:lang="en">Phase occurring in terminal areas near river mouths or spawning areas (often including terminal fisheries and local migration to spawning sites).</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/LifePhaseScheme"/>
@@ -4678,6 +4820,7 @@
 
     <rdf:Description rdf:about="https://w3id.org/gcdfo/salmon#ConfidenceCategory">
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Confidence category</rdfs:label>
         <skos:definition xml:lang="en">Categorical confidence rating (High, Medium, Low) for stock assessment metrics.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme"/>
         <skos:prefLabel xml:lang="en">Confidence category</skos:prefLabel>
@@ -4686,6 +4829,7 @@
     </rdf:Description>
     <rdf:Description rdf:about="https://w3id.org/gcdfo/salmon#IntegratedStatusOutcome">
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Integrated status outcome</rdfs:label>
         <skos:definition xml:lang="en">Outcome category assigned by integrated WSP status workflows for a Conservation Unit.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#IntegratedStatusOutcomeScheme"/>
         <skos:prefLabel xml:lang="en">Integrated status outcome</skos:prefLabel>
@@ -4696,6 +4840,7 @@
         <obo:IAO_0000119 xml:lang="en">Fisheries and Oceans Canada. Wild Salmon Policy 2018-2022 Implementation Plan. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf.</obo:IAO_0000119>
         <dcterms:source rdf:resource="https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/gcdfo/salmon"/>
+        <rdfs:label xml:lang="en">Wild Salmon Policy biological status zone</rdfs:label>
         <skos:definition xml:lang="en">The biological status of a Conservation Unit (CU) will normally be based on the abundance and distribution of spawners in the unit, or proxies thereof. For each CU, higher and lower benchmarks will be defined that will delimit three status zones: Green, Amber, and Red. As spawner abundance decreases, a CU moves towards the lower status zone, and the extent of management intervention for conservation purposes will increase.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/gcdfo/salmon#WSPBiologicalStatusZoneScheme"/>
         <skos:prefLabel xml:lang="en">Wild Salmon Policy biological status zone</skos:prefLabel>

--- a/docs/gcdfo.ttl
+++ b/docs/gcdfo.ttl
@@ -1492,6 +1492,7 @@ gcdfo:AbsoluteAbundanceMetricStatus rdf:type owl:NamedIndividual ,
                                              skos:Concept ;
                                     dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv> ;
                                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                    rdfs:label "Absolute abundance metric status"@en ;
                                     skos:altLabel "AbsAbdCat"@en ;
                                     skos:broader gcdfo:WSPOutputVariable ;
                                     skos:definition "Categorical status derived from the absolute abundance metric benchmark ratio."@en ;
@@ -1514,6 +1515,7 @@ gcdfo:AbundanceDataType rdf:type owl:NamedIndividual ,
                         <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004."@en ;
                         dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf> ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "Abundance data type"@en ;
                         skos:broader smn:MeasurementContext ;
                         skos:definition "A categorical attribute indicating whether an abundance time series is recorded as absolute abundance or as a relative index (used by rapid-status workflows)."@en ;
                         skos:inScheme smn:MeasurementContextScheme ;
@@ -1532,6 +1534,7 @@ gcdfo:AbundancePercentileMetric rdf:type owl:NamedIndividual ,
                                 <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004."@en ;
                                 dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf> ;
                                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                rdfs:label "Abundance percentile metric"@en ;
                                 skos:broader gcdfo:RapidStatusMetric ;
                                 skos:definition "An abundance percentile metric giving the percentile rank of the current generational average spawner abundance relative to a historical reference distribution."@en ;
                                 skos:inScheme gcdfo:RapidStatusMetricScheme ;
@@ -1549,6 +1552,7 @@ gcdfo:AbundancePercentileMetricStatus rdf:type owl:NamedIndividual ,
                                                skos:Concept ;
                                       dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv> ;
                                       rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                      rdfs:label "Abundance percentile metric status"@en ;
                                       skos:altLabel "PercentileCat"@en ;
                                       skos:broader gcdfo:WSPOutputVariable ;
                                       skos:definition "Categorical status derived from abundance percentile metric values."@en ;
@@ -1568,6 +1572,7 @@ gcdfo:AerialSurveyCount rdf:type owl:NamedIndividual ,
                                  skos:Concept ;
                         rdfs:comment "Legacy methods: Helicopter, Fixed Wing Aircraft, Aerial, Drone, UAS, UAV"@en ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "Aerial Survey Count"@en ;
                         skos:broader smn:EnumerationMethod ;
                         skos:definition "Overflights (helicopter, fixed wing, or drone) with documented flight lines, coverage, visibility, and sensor settings. Imagery may be reviewed post-flight."@en ;
                         skos:inScheme gcdfo:EnumerationMethodScheme ;
@@ -1580,6 +1585,7 @@ gcdfo:AerialSurveyCount rdf:type owl:NamedIndividual ,
 gcdfo:Age1YearClass rdf:type owl:NamedIndividual ,
                              skos:Concept ;
                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:label "Age 1 year class"@en ;
                     skos:broader gcdfo:AgeClassValue ;
                     skos:definition "Age class value 1 year."@en ;
                     skos:inScheme gcdfo:AgeClassValueScheme ;
@@ -1592,6 +1598,7 @@ gcdfo:Age1YearClass rdf:type owl:NamedIndividual ,
 gcdfo:Age2YearClass rdf:type owl:NamedIndividual ,
                              skos:Concept ;
                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:label "Age 2 year class"@en ;
                     skos:broader gcdfo:AgeClassValue ;
                     skos:definition "Age class value 2 years."@en ;
                     skos:inScheme gcdfo:AgeClassValueScheme ;
@@ -1604,6 +1611,7 @@ gcdfo:Age2YearClass rdf:type owl:NamedIndividual ,
 gcdfo:Age3YearClass rdf:type owl:NamedIndividual ,
                              skos:Concept ;
                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:label "Age 3 year class"@en ;
                     skos:broader gcdfo:AgeClassValue ;
                     skos:definition "Age class value 3 years."@en ;
                     skos:inScheme gcdfo:AgeClassValueScheme ;
@@ -1616,6 +1624,7 @@ gcdfo:Age3YearClass rdf:type owl:NamedIndividual ,
 gcdfo:Age4YearClass rdf:type owl:NamedIndividual ,
                              skos:Concept ;
                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:label "Age 4 year class"@en ;
                     skos:broader gcdfo:AgeClassValue ;
                     skos:definition "Age class value 4 years."@en ;
                     skos:inScheme gcdfo:AgeClassValueScheme ;
@@ -1628,6 +1637,7 @@ gcdfo:Age4YearClass rdf:type owl:NamedIndividual ,
 gcdfo:Age5YearClass rdf:type owl:NamedIndividual ,
                              skos:Concept ;
                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:label "Age 5 year class"@en ;
                     skos:broader gcdfo:AgeClassValue ;
                     skos:definition "Age class value 5 years."@en ;
                     skos:inScheme gcdfo:AgeClassValueScheme ;
@@ -1640,6 +1650,7 @@ gcdfo:Age5YearClass rdf:type owl:NamedIndividual ,
 gcdfo:Age6YearClass rdf:type owl:NamedIndividual ,
                              skos:Concept ;
                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:label "Age 6 year class"@en ;
                     skos:broader gcdfo:AgeClassValue ;
                     skos:definition "Age class value 6 years."@en ;
                     skos:inScheme gcdfo:AgeClassValueScheme ;
@@ -1652,6 +1663,7 @@ gcdfo:Age6YearClass rdf:type owl:NamedIndividual ,
 gcdfo:Age7YearClass rdf:type owl:NamedIndividual ,
                              skos:Concept ;
                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:label "Age 7 year class"@en ;
                     skos:broader gcdfo:AgeClassValue ;
                     skos:definition "Age class value 7 years."@en ;
                     skos:inScheme gcdfo:AgeClassValueScheme ;
@@ -1664,6 +1676,7 @@ gcdfo:Age7YearClass rdf:type owl:NamedIndividual ,
 gcdfo:AgeAtMaturityBasis rdf:type owl:NamedIndividual ,
                                   skos:Concept ;
                          rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                         rdfs:label "Age at maturity basis"@en ;
                          skos:broader gcdfo:AgeBasis ;
                          skos:definition "Age measured at maturity."@en ;
                          skos:inScheme gcdfo:AgeBasisScheme ;
@@ -1676,6 +1689,7 @@ gcdfo:AgeAtMaturityBasis rdf:type owl:NamedIndividual ,
 gcdfo:AgeAtReturnBasis rdf:type owl:NamedIndividual ,
                                 skos:Concept ;
                        rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                       rdfs:label "Age at return basis"@en ;
                        skos:broader gcdfo:AgeBasis ;
                        skos:definition "Age measured at return migration (adult return timing)."@en ;
                        skos:inScheme gcdfo:AgeBasisScheme ;
@@ -1688,6 +1702,7 @@ gcdfo:AgeAtReturnBasis rdf:type owl:NamedIndividual ,
 gcdfo:AgeAtSamplingBasis rdf:type owl:NamedIndividual ,
                                   skos:Concept ;
                          rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                         rdfs:label "Age at sampling basis"@en ;
                          skos:broader gcdfo:AgeBasis ;
                          skos:definition "Age measured at the time of sampling or observation."@en ;
                          skos:inScheme gcdfo:AgeBasisScheme ;
@@ -1700,6 +1715,7 @@ gcdfo:AgeAtSamplingBasis rdf:type owl:NamedIndividual ,
 gcdfo:AgeBasis rdf:type owl:NamedIndividual ,
                         skos:Concept ;
                rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+               rdfs:label "Age basis"@en ;
                skos:definition "The reference event or life-history point that an age value is measured against."@en ;
                skos:inScheme gcdfo:AgeBasisScheme ;
                skos:prefLabel "Age basis"@en ;
@@ -1722,6 +1738,7 @@ gcdfo:AgeBasisScheme rdf:type owl:NamedIndividual ,
 gcdfo:AgeClassValue rdf:type owl:NamedIndividual ,
                              skos:Concept ;
                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:label "Age class value"@en ;
                     skos:definition "An integer-like age class value used as a compositional constraint in salmon measurements."@en ;
                     skos:inScheme gcdfo:AgeClassValueScheme ;
                     skos:prefLabel "Age class value"@en ;
@@ -1742,6 +1759,7 @@ gcdfo:AgeClassValueScheme rdf:type owl:NamedIndividual ,
 gcdfo:AgeDimension rdf:type owl:NamedIndividual ,
                             skos:Concept ;
                    rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                   rdfs:label "Age dimension"@en ;
                    skos:definition "The age component represented by a value (total age, freshwater years, or ocean years)."@en ;
                    skos:inScheme gcdfo:AgeDimensionScheme ;
                    skos:prefLabel "Age dimension"@en ;
@@ -1762,6 +1780,7 @@ gcdfo:AgeDimensionScheme rdf:type owl:NamedIndividual ,
 gcdfo:AgeNotation rdf:type owl:NamedIndividual ,
                            skos:Concept ;
                   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                  rdfs:label "Age notation"@en ;
                   skos:definition "A notation system used to encode salmon age values in stock assessment data."@en ;
                   skos:inScheme gcdfo:AgeNotationScheme ;
                   skos:prefLabel "Age notation"@en ;
@@ -1788,6 +1807,7 @@ gcdfo:AmberZone rdf:type owl:NamedIndividual ,
                 <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Wild Salmon Policy 2018-2022 Implementation Plan. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf."@en ;
                 dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf> ;
                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                rdfs:label "Amber zone"@en ;
                 skos:definition "Amber status implies caution in the management of the Conservation Unit. While a CU in the Amber zone should be at a low risk of loss, there will be a degree of lost production. Decisions about the conservation of CUs in the Amber zone will involve broader consideration of biological, social, and economic issues. "@en ;
                 skos:inScheme gcdfo:IntegratedStatusOutcomeScheme ,
                               gcdfo:WSPBiologicalStatusZoneScheme ;
@@ -1801,6 +1821,7 @@ gcdfo:AmberZone rdf:type owl:NamedIndividual ,
 gcdfo:AreaUnderTheCurve rdf:type owl:NamedIndividual ,
                                  skos:Concept ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "Area Under the Curve"@en ;
                         skos:altLabel "AUC"@en ;
                         skos:broader gcdfo:EstimateMethod ;
                         skos:definition "Integrates serial counts over time using a survey-life parameter; may apply observer efficiency."@en ;
@@ -1828,6 +1849,7 @@ gcdfo:BenchmarkRatioMetric rdf:type owl:NamedIndividual ,
                            <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004."@en ;
                            dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf> ;
                            rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                           rdfs:label "Benchmark ratio metric"@en ;
                            skos:broader gcdfo:RapidStatusMetric ;
                            skos:definition "A benchmark-ratio metric equal to the ratio of current generational average spawner abundance to a specified benchmark (lower or upper benchmark), where 1.0 indicates equality to that benchmark."@en ;
                            skos:inScheme gcdfo:RapidStatusMetricScheme ;
@@ -1857,6 +1879,7 @@ gcdfo:BreachBypass rdf:type owl:NamedIndividual ,
                             skos:Concept ;
                    rdfs:comment "Limits to Type 2 maximum"@en ;
                    rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                   rdfs:label "Bypass/Breach Risk"@en ;
                    skos:broader gcdfo:DowngradeCriteria ;
                    skos:definition "Bypass or breach risks not monitored and verified negligible"@en ;
                    skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -1872,6 +1895,7 @@ gcdfo:BroodYear rdf:type owl:NamedIndividual ,
                 <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Pacific Salmon - Glossary (Pacific Region). https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html."@en ;
                 dcterms:source <https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html> ;
                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                rdfs:label "Brood year"@en ;
                 skos:broader gcdfo:YearBasis ;
                 skos:closeMatch odo:SALMON_00000520 ;
                 skos:definition "The parental year for a group of returning salmon, i.e. the calendar year when the majority of parents of these fish spawned."@en ;
@@ -1898,6 +1922,7 @@ gcdfo:CalibratedTimeSeries rdf:type owl:NamedIndividual ,
                                     skos:Concept ;
                            rdfs:comment "Document calibration source years, transferability, diagnostics. Type-2 when calibration robust and applicable; else Type-3."@en ;
                            rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                           rdfs:label "Calibrated Time Series"@en ;
                            skos:broader gcdfo:EstimateMethod ;
                            skos:definition "Regression/state-space model calibrated to a Type-1/2 series converts a lower-precision index to abundance."@en ;
                            skos:inScheme gcdfo:EstimateMethodScheme ;
@@ -1911,6 +1936,7 @@ gcdfo:CatchYear rdf:type owl:NamedIndividual ,
                          skos:Concept ;
                 <http://purl.obolibrary.org/obo/IAO_0000115> "The calendar year in which returning salmon are caught in fisheries (as opposed to the brood year in which the cohort was spawned)."@en ;
                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                rdfs:label "Catch year"@en ;
                 skos:broader gcdfo:YearBasis ;
                 skos:definition "The calendar year in which returning salmon are caught in fisheries (as opposed to the brood year in which the cohort was spawned)."@en ;
                 skos:inScheme gcdfo:YearBasisScheme ;
@@ -1924,6 +1950,7 @@ gcdfo:Classification rdf:type owl:NamedIndividual ,
                               skos:Concept ;
                      rdfs:comment "Limits to Type 3 maximum"@en ;
                      rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                     rdfs:label "Classification"@en ;
                      skos:broader gcdfo:DowngradeCriteria ;
                      skos:definition "Classification/attribution not documented"@en ;
                      skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -1942,6 +1969,7 @@ gcdfo:ConservationUnitName rdf:type owl:NamedIndividual ,
                                     skos:Concept ;
                            dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv> ;
                            rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                           rdfs:label "Conservation Unit name"@en ;
                            skos:altLabel "Stock (canonical WSP output column label)"@en ;
                            skos:broader gcdfo:WSPOutputVariable ;
                            skos:definition "Full Conservation Unit name field used in canonical WSP outputs."@en ;
@@ -1959,6 +1987,7 @@ gcdfo:CrossSectionCoverage rdf:type owl:NamedIndividual ,
                                     skos:Concept ;
                            rdfs:comment "Limits to Type 2 maximum"@en ;
                            rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                           rdfs:label "Cross-section Coverage"@en ;
                            skos:broader gcdfo:DowngradeCriteria ;
                            skos:definition "Incomplete cross-section coverage"@en ;
                            skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -1971,6 +2000,7 @@ gcdfo:CrossSectionCoverage rdf:type owl:NamedIndividual ,
 gcdfo:DataModelProvenanceTheme rdf:type owl:NamedIndividual ,
                                         skos:Concept ;
                                rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                               rdfs:label "Data, Models, and Provenance"@en ;
                                skos:definition "Data models, analytical workflows, provenance, quality dimensions, and metadata supporting salmon science."@en ;
                                skos:inScheme gcdfo:ThemeScheme ;
                                skos:prefLabel "Data, Models, and Provenance"@en ;
@@ -1981,6 +2011,7 @@ gcdfo:DataModelProvenanceTheme rdf:type owl:NamedIndividual ,
 gcdfo:DataQualityRatingContext rdf:type owl:NamedIndividual ,
                                         skos:Concept ;
                                rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                               rdfs:label "Data quality rating context"@en ;
                                skos:broader smn:MeasurementContext ;
                                skos:definition "Measurement context indicating categorical or ordinal quality ratings."@en ;
                                skos:inScheme smn:MeasurementContextScheme ;
@@ -1993,6 +2024,7 @@ gcdfo:Detectability rdf:type owl:NamedIndividual ,
                              skos:Concept ;
                     rdfs:comment "Limits to Type 3 maximum"@en ;
                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:label "Detectability"@en ;
                     skos:broader gcdfo:DowngradeCriteria ;
                     skos:definition "Detectability factors not validated"@en ;
                     skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -2006,6 +2038,7 @@ gcdfo:DeviceConfiguration rdf:type owl:NamedIndividual ,
                                    skos:Concept ;
                           rdfs:comment "Limits to Type 2 maximum"@en ;
                           rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                          rdfs:label "Device Configuration"@en ;
                           skos:broader gcdfo:DowngradeCriteria ;
                           skos:definition "Device not within operational specifications"@en ;
                           skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -2019,6 +2052,7 @@ gcdfo:Documentation rdf:type owl:NamedIndividual ,
                              skos:Concept ;
                     rdfs:comment "Downgrades Type 1/2 by one level"@en ;
                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:label "Documentation"@en ;
                     skos:broader gcdfo:DowngradeCriteria ;
                     skos:definition "Missing SIL/SEN logs or QA/methods report"@en ;
                     skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -2031,6 +2065,7 @@ gcdfo:Documentation rdf:type owl:NamedIndividual ,
 gcdfo:DowngradeCriteria rdf:type owl:NamedIndividual ,
                                  skos:Concept ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "Downgrade Criteria"@en ;
                         skos:definition "Criteria that may result in downgrading an escapement estimate type classification"@en ;
                         skos:inScheme gcdfo:DowngradeCriteriaScheme ;
                         skos:prefLabel "Downgrade Criteria"@en ;
@@ -2053,6 +2088,7 @@ gcdfo:EffortStandardization rdf:type owl:NamedIndividual ,
                                      skos:Concept ;
                             rdfs:comment "Limits to Type 4 maximum"@en ;
                             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                            rdfs:label "Effort Standardization"@en ;
                             skos:broader gcdfo:DowngradeCriteria ;
                             skos:definition "Effort not standardized"@en ;
                             skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -2066,6 +2102,7 @@ gcdfo:ElectrofishingCount rdf:type owl:NamedIndividual ,
                                    skos:Concept ;
                           rdfs:comment "Legacy methods: Electrofishing, Electroshocking"@en ;
                           rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                          rdfs:label "Electrofishing Count"@en ;
                           skos:broader smn:EnumerationMethod ;
                           skos:definition "Effort-standardized electrofishing passes used to generate catch-per-unit-effort (CPUE) indices."@en ;
                           skos:inScheme gcdfo:EnumerationMethodScheme ;
@@ -2089,6 +2126,7 @@ gcdfo:EnvironmentalConditions rdf:type owl:NamedIndividual ,
                                        skos:Concept ;
                               rdfs:comment "Limits to Type 2 maximum"@en ;
                               rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                              rdfs:label "Environmental Conditions"@en ;
                               skos:broader gcdfo:DowngradeCriteria ;
                               skos:definition "Environmental conditions outside specifications"@en ;
                               skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -2101,6 +2139,7 @@ gcdfo:EnvironmentalConditions rdf:type owl:NamedIndividual ,
 gcdfo:EstimateMethod rdf:type owl:NamedIndividual ,
                               skos:Concept ;
                      rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                     rdfs:label "Estimate Method"@en ;
                      skos:definition "A method used to analyze and estimate salmon abundance from enumeration data"@en ;
                      skos:inScheme gcdfo:EstimateMethodScheme ;
                      skos:prefLabel "Estimate Method"@en ;
@@ -2122,6 +2161,7 @@ gcdfo:EstimateMethodScheme rdf:type owl:NamedIndividual ,
 gcdfo:EstimateType rdf:type owl:NamedIndividual ,
                             skos:Concept ;
                    rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                   rdfs:label "Estimate Type"@en ;
                    skos:definition "Classification of escapement estimate quality based on Hyatt 1997 framework"@en ;
                    skos:inScheme gcdfo:EstimateTypeScheme ;
                    skos:prefLabel "Estimate Type"@en ;
@@ -2144,6 +2184,7 @@ gcdfo:EuropeanAgeNotation rdf:type owl:NamedIndividual ,
                                    skos:Concept ;
                           dcterms:source <https://www.pac.dfo-mpo.gc.ca/fm-gp/fraser/docs/archiv-reports-rapports/indigenous-autochtone/2010FrasRvrChkInformDoc.htm> ;
                           rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                          rdfs:label "European age notation"@en ;
                           skos:broader gcdfo:AgeNotation ;
                           skos:definition "Salmon age notation that records freshwater years followed by ocean years (for example, 1.2)."@en ;
                           skos:inScheme gcdfo:AgeNotationScheme ;
@@ -2160,6 +2201,7 @@ gcdfo:ExpansionFactor rdf:type owl:NamedIndividual ,
                       <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2021. Marine Survival Forecast of Southern British Columbia Coho (describes applying expansion factors to PIT detections to estimate total escapement)."@en ;
                       dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/Library/40978680.pdf> ;
                       rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                      rdfs:label "Expansion factor"@en ;
                       skos:broader gcdfo:ExpansionMathematicalOperations ;
                       skos:definition "A multiplicative factor used to expand observed counts or detections from a sampled subset (e.g., indicator sites, PIT detections) to an estimated total abundance or escapement."@en ;
                       skos:inScheme gcdfo:EstimateMethodScheme ;
@@ -2173,6 +2215,7 @@ gcdfo:ExpansionMathematicalOperations rdf:type owl:NamedIndividual ,
                                                skos:Concept ;
                                       rdfs:comment "Legacy methods: Lake Expansion, Redd Expansion, Peak×Factor, (Peak+CumDead)×Factor, Addition/Subtraction, Multiplication/Division. Inherits base method's Type; weak provenance = downgrade one Type."@en ;
                                       rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                      rdfs:label "Expansion/Mathematical Operations"@en ;
                                       skos:broader gcdfo:EstimateMethod ;
                                       skos:definition "Applies expansion factors or arithmetic transforms to a base count/index."@en ;
                                       skos:inScheme gcdfo:EstimateMethodScheme ;
@@ -2185,6 +2228,7 @@ gcdfo:ExpansionMathematicalOperations rdf:type owl:NamedIndividual ,
 gcdfo:FishStockProvisions rdf:type owl:NamedIndividual ,
                                    skos:Concept ;
                           rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                          rdfs:label "Fish Stocks Provisions"@en ;
                           skos:altLabel "FSP"@en ;
                           skos:broader gcdfo:PolicyFramework ;
                           skos:definition "Legal provisions in Canada's Fisheries Act and regulations related to maintaining and rebuilding fish stocks, including obligations triggered when reference points are breached."@en ;
@@ -2199,6 +2243,7 @@ gcdfo:FishStockProvisions rdf:type owl:NamedIndividual ,
 gcdfo:FisheriesManagementTheme rdf:type owl:NamedIndividual ,
                                         skos:Concept ;
                                rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                               rdfs:label "Fisheries Management"@en ;
                                skos:definition "Fishery openings, harvest control rules, catch/effort measures, and exploitation monitoring for salmon fisheries."@en ;
                                skos:inScheme gcdfo:ThemeScheme ;
                                skos:prefLabel "Fisheries Management"@en ;
@@ -2210,6 +2255,7 @@ gcdfo:FixedSiteCensusElectronic rdf:type owl:NamedIndividual ,
                                          skos:Concept ;
                                 rdfs:comment "Legacy methods: Electronic/Optical counter, Resistivity Counter, Video/Camera counter"@en ;
                                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                rdfs:label "Fixed Site Census (Electronic)"@en ;
                                 skos:broader smn:EnumerationMethod ;
                                 skos:definition "Automated counting at a constrained opening using electronic/optical counters, resistivity counters, or video/camera systems. QA review of automated events, cross-section coverage, and uptime/coverage are documented."@en ;
                                 skos:inScheme gcdfo:EnumerationMethodScheme ;
@@ -2223,6 +2269,7 @@ gcdfo:FixedSiteCensusManual rdf:type owl:NamedIndividual ,
                                      skos:Concept ;
                             rdfs:comment "Legacy methods: Fence, Weir, Fixed Site Census (manual)"@en ;
                             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                            rdfs:label "Fixed Site Census (Manual)"@en ;
                             skos:broader smn:EnumerationMethod ;
                             skos:definition "Salmon are guided through a controlled opening in a fence/weir where trained observers visually tally each passage event on a continuous or daily schedule. Counting chambers/windows and SIL/SEN daily logs document coverage; bypass routes are monitored and closed where possible."@en ;
                             skos:inScheme gcdfo:EnumerationMethodScheme ;
@@ -2235,6 +2282,7 @@ gcdfo:FixedSiteCensusManual rdf:type owl:NamedIndividual ,
 gcdfo:FixedStationTally rdf:type owl:NamedIndividual ,
                                  skos:Concept ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "Fixed‑Station Tally"@en ;
                         skos:broader gcdfo:EstimateMethod ;
                         skos:definition "Seasonal total = roll‑up of daily/continuous counts from a fixed (non‑sonar) station; simple arithmetic with documented coverage."@en ;
                         skos:inScheme gcdfo:EstimateMethodScheme ;
@@ -2247,6 +2295,7 @@ gcdfo:FixedStationTally rdf:type owl:NamedIndividual ,
 gcdfo:FreshwaterAgeDimension rdf:type owl:NamedIndividual ,
                                       skos:Concept ;
                              rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                             rdfs:label "Freshwater age dimension"@en ;
                              skos:broader gcdfo:AgeDimension ;
                              skos:definition "Age value represents years spent in freshwater."@en ;
                              skos:inScheme gcdfo:AgeDimensionScheme ;
@@ -2262,6 +2311,7 @@ gcdfo:GenerationalAverageAbundance rdf:type owl:NamedIndividual ,
                                    <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004."@en ;
                                    dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf> ;
                                    rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                   rdfs:label "Generational average abundance"@en ;
                                    skos:broader gcdfo:RapidStatusMetric ;
                                    skos:definition "The generational average of spawner abundance, calculated as a geometric mean across the number of years corresponding to the most common age at return (generation length), optionally after smoothing depending on CU group."@en ;
                                    skos:inScheme gcdfo:RapidStatusMetricScheme ;
@@ -2278,6 +2328,7 @@ gcdfo:GenerationalAverageAbundance rdf:type owl:NamedIndividual ,
 gcdfo:GeneticsStockCompositionTheme rdf:type owl:NamedIndividual ,
                                              skos:Concept ;
                                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                    rdfs:label "Genetics and Stock Composition"@en ;
                                     skos:definition "Genetic markers, assays, and analyses used to infer stock composition, parentage, and population structure."@en ;
                                     skos:inScheme gcdfo:ThemeScheme ;
                                     skos:prefLabel "Genetics and Stock Composition"@en ;
@@ -2289,6 +2340,7 @@ gcdfo:GilbertRichAgeNotation rdf:type owl:NamedIndividual ,
                                       skos:Concept ;
                              dcterms:source <https://www.pac.dfo-mpo.gc.ca/fm-gp/fraser/docs/archiv-reports-rapports/indigenous-autochtone/2010FrasRvrChkInformDoc.htm> ;
                              rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                             rdfs:label "Gilbert-Rich age notation"@en ;
                              skos:altLabel "GR age notation"@en ;
                              skos:broader gcdfo:AgeNotation ;
                              skos:definition "Salmon age notation where total age is annotated with freshwater years as a subscript-like suffix (for example, 4_2 for total age 4 with 2 freshwater years)."@en ;
@@ -2307,6 +2359,7 @@ gcdfo:GreenZone rdf:type owl:NamedIndividual ,
                 <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Wild Salmon Policy 2018-2022 Implementation Plan. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf."@en ;
                 dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf> ;
                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                rdfs:label "Green zone"@en ;
                 skos:definition "Social and economic considerations will tend to be the primary drivers for the management of Conservation Units in the Green zone, though ecosystem or other non-consumptive use values could also be considered."@en ;
                 skos:inScheme gcdfo:IntegratedStatusOutcomeScheme ,
                               gcdfo:WSPBiologicalStatusZoneScheme ;
@@ -2320,6 +2373,7 @@ gcdfo:GreenZone rdf:type owl:NamedIndividual ,
 gcdfo:HabitatEcosystemClimateTheme rdf:type owl:NamedIndividual ,
                                             skos:Concept ;
                                    rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                   rdfs:label "Habitat, Ecosystem, and Climate Pressures"@en ;
                                    skos:definition "Habitat attributes, ecosystem conditions, and climate or environmental stressors affecting salmon."@en ;
                                    skos:inScheme gcdfo:ThemeScheme ;
                                    skos:prefLabel "Habitat, Ecosystem, and Climate Pressures"@en ;
@@ -2331,6 +2385,7 @@ gcdfo:HydroacousticModelling rdf:type owl:NamedIndividual ,
                                       skos:Concept ;
                              rdfs:comment "Legacy methods: Hydroacoustics, Sonar (ARIS/DIDSON). Not Type-1 under Hyatt; interpolation and classification error are central downgrades."@en ;
                              rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                             rdfs:label "Hydroacoustic Modelling"@en ;
                              skos:broader gcdfo:EstimateMethod ;
                              skos:definition "Model pipeline converts sonar detections to passage totals; sets range/angle/blind zones; species/size attribution rules documented."@en ;
                              skos:inScheme gcdfo:EstimateMethodScheme ;
@@ -2344,6 +2399,7 @@ gcdfo:HydroacousticSonarCount rdf:type owl:NamedIndividual ,
                                        skos:Concept ;
                               rdfs:comment "Legacy methods: Sonar-ARIS, Sonar-DIDSON, Hydroacoustic"@en ;
                               rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                              rdfs:label "Hydroacoustic Sonar Count"@en ;
                               skos:broader smn:EnumerationMethod ;
                               skos:definition "Sonar detections (ARIS, DIDSON, or other hydroacoustic systems) with documented coverage, visibility/noise conditions, and uptime. Raw detections require processing through a modelling/classification pipeline."@en ;
                               skos:inScheme gcdfo:EnumerationMethodScheme ;
@@ -2357,6 +2413,7 @@ gcdfo:InfillMethod rdf:type owl:NamedIndividual ,
                             skos:Concept ;
                    rdfs:comment "Limits to Type 2 maximum"@en ;
                    rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                   rdfs:label "Infill Method"@en ;
                    skos:broader gcdfo:DowngradeCriteria ;
                    skos:definition "Interpolation used for missing data; defensibility must be documented"@en ;
                    skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -2372,6 +2429,7 @@ gcdfo:IntegratedStatusAmberGreen rdf:type owl:NamedIndividual ,
                                  <http://purl.obolibrary.org/obo/IAO_0000119> "Approved WSP statuses output uses IntStatusRaw value AmberGreen and IntStatusRaw_Short code AG."@en ;
                                  dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv> ;
                                  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                 rdfs:label "Amber/Green integrated status"@en ;
                                  skos:definition "Blended integrated status outcome between Amber and Green used when expert evidence supports an intermediate boundary outcome."@en ;
                                  skos:inScheme gcdfo:IntegratedStatusOutcomeScheme ;
                                  skos:notation "AG" ;
@@ -2388,6 +2446,7 @@ gcdfo:IntegratedStatusBinary rdf:type owl:NamedIndividual ,
                                       skos:Concept ;
                              dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv> ;
                              rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                             rdfs:label "Integrated status (binary red/not-red)"@en ;
                              owl:deprecated "true"^^xsd:boolean ;
                              skos:altLabel "IntStatus2"@en ;
                              skos:broader gcdfo:WSPOutputVariable ;
@@ -2407,6 +2466,7 @@ gcdfo:IntegratedStatusCollapsedCode rdf:type owl:NamedIndividual ,
                                              skos:Concept ;
                                     dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv> ;
                                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                    rdfs:label "Collapsed integrated status code"@en ;
                                     skos:altLabel "IntStatus_Short"@en ;
                                     skos:broader gcdfo:WSPOutputVariable ;
                                     skos:definition "Short code representation of the three-category collapsed integrated status field."@en ;
@@ -2427,6 +2487,7 @@ gcdfo:IntegratedStatusDataDeficient rdf:type owl:NamedIndividual ,
                                     <http://purl.obolibrary.org/obo/IAO_0000119> "WSP integrated-status documentation defines data deficient outcomes where status cannot be assigned because information is insufficient."@en ;
                                     dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv> ;
                                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                    rdfs:label "Data deficient integrated status"@en ;
                                     skos:definition "Integrated status outcome indicating insufficient information to assign a biological zone outcome."@en ;
                                     skos:inScheme gcdfo:IntegratedStatusOutcomeScheme ;
                                     skos:notation "DD" ;
@@ -2441,6 +2502,7 @@ gcdfo:IntegratedStatusFiveCategoryAlias rdf:type owl:NamedIndividual ,
                                                  skos:Concept ;
                                         dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv> ;
                                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                        rdfs:label "Integrated status (5-category legacy alias)"@en ;
                                         owl:deprecated "true"^^xsd:boolean ;
                                         skos:altLabel "IntStatus5"@en ;
                                         skos:broader gcdfo:WSPOutputVariable ;
@@ -2460,6 +2522,7 @@ gcdfo:IntegratedStatusNotRed rdf:type owl:NamedIndividual ,
                                       gcdfo:IntegratedStatusOutcome ;
                              dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv> ;
                              rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                             rdfs:label "Not-red integrated status"@en ;
                              skos:definition "Binary integrated-status outcome indicating the Conservation Unit is not in Red status after binary collapse of integrated outcomes."@en ;
                              skos:inScheme gcdfo:IntegratedStatusOutcomeScheme ;
                              skos:notation "NotRed" ;
@@ -2491,6 +2554,7 @@ gcdfo:IntegratedStatusRaw rdf:type owl:NamedIndividual ,
                                    skos:Concept ;
                           dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv> ;
                           rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                          rdfs:label "Integrated status (raw)"@en ;
                           skos:altLabel "IntStatusRaw"@en ;
                           skos:broader gcdfo:WSPOutputVariable ;
                           skos:definition "Expert-assigned integrated WSP status outcome prior to collapsed-category derivations."@en ;
@@ -2510,6 +2574,7 @@ gcdfo:IntegratedStatusRawCode rdf:type owl:NamedIndividual ,
                                        skos:Concept ;
                               dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv> ;
                               rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                              rdfs:label "Raw integrated status code"@en ;
                               skos:altLabel "IntStatusRaw_Short"@en ;
                               skos:broader gcdfo:WSPOutputVariable ;
                               skos:definition "Short code representation of IntegratedStatusRaw values."@en ;
@@ -2530,6 +2595,7 @@ gcdfo:IntegratedStatusRedAmber rdf:type owl:NamedIndividual ,
                                <http://purl.obolibrary.org/obo/IAO_0000119> "Approved WSP statuses output uses IntStatusRaw value RedAmber and IntStatusRaw_Short code RA."@en ;
                                dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv> ;
                                rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                               rdfs:label "Red/Amber integrated status"@en ;
                                skos:definition "Blended integrated status outcome between Red and Amber used when expert evidence supports an intermediate boundary outcome."@en ;
                                skos:inScheme gcdfo:IntegratedStatusOutcomeScheme ;
                                skos:notation "RA" ;
@@ -2546,6 +2612,7 @@ gcdfo:IntegratedStatusThreeCategory rdf:type owl:NamedIndividual ,
                                              skos:Concept ;
                                     dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv> ;
                                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                    rdfs:label "Integrated status (3-category collapsed)"@en ;
                                     owl:deprecated "true"^^xsd:boolean ;
                                     skos:altLabel "IntStatus3"@en ;
                                     skos:broader gcdfo:WSPOutputVariable ;
@@ -2567,6 +2634,7 @@ gcdfo:IntegratedStatusUndetermined rdf:type owl:NamedIndividual ,
                                    <http://purl.obolibrary.org/obo/IAO_0000119> "Approved WSP statuses output uses UD for undetermined integrated-status outcomes."@en ;
                                    dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved.csv> ;
                                    rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                   rdfs:label "Undetermined integrated status"@en ;
                                    skos:altLabel "to be determined"@en ;
                                    skos:definition "Integrated status outcome used when an assessment is unresolved or pending completion."@en ;
                                    skos:inScheme gcdfo:IntegratedStatusOutcomeScheme ;
@@ -2585,6 +2653,7 @@ gcdfo:LongTermTrendMetric rdf:type owl:NamedIndividual ,
                           <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004."@en ;
                           dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf> ;
                           rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                          rdfs:label "Long-term trend metric"@en ;
                           skos:broader gcdfo:RapidStatusMetric ;
                           skos:definition "A long-term trend metric comparing the current generational average (geometric mean) spawner abundance to the long-term average (geometric mean) spawner abundance for an assessed time series."@en ;
                           skos:inScheme gcdfo:RapidStatusMetricScheme ;
@@ -2602,6 +2671,7 @@ gcdfo:LongTermTrendMetricStatus rdf:type owl:NamedIndividual ,
                                          skos:Concept ;
                                 dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv> ;
                                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                rdfs:label "Long-term trend metric status"@en ;
                                 skos:altLabel "LongTrendCat"@en ;
                                 skos:broader gcdfo:WSPOutputVariable ;
                                 skos:definition "Categorical status derived from the long-term trend metric using WSP status-zone thresholds."@en ;
@@ -2620,6 +2690,7 @@ gcdfo:LongTermTrendMetricStatus rdf:type owl:NamedIndividual ,
 gcdfo:LowerBenchmark rdf:type owl:NamedIndividual ,
                               skos:Concept ;
                      rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                     rdfs:label "Lower benchmark"@en ;
                      skos:definition "A lower-threshold benchmark value, typically delineating the boundary between Red and Amber status zones."@en ;
                      skos:inScheme gcdfo:BenchmarkLevelScheme ;
                      skos:prefLabel "Lower benchmark"@en ;
@@ -2631,6 +2702,7 @@ gcdfo:LowerBenchmark rdf:type owl:NamedIndividual ,
 gcdfo:ManagementReferenceContext rdf:type owl:NamedIndividual ,
                                           skos:Concept ;
                                  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                 rdfs:label "Management reference context"@en ;
                                  skos:broader smn:MeasurementContext ;
                                  skos:definition "Measurement context indicating values are management benchmarks or reference-oriented metrics."@en ;
                                  skos:inScheme smn:MeasurementContextScheme ;
@@ -2644,6 +2716,7 @@ gcdfo:MarkRecaptureAnalysis rdf:type owl:NamedIndividual ,
                                      skos:Concept ;
                             rdfs:comment "Legacy methods: Petersen, Jolly-Seber, Open model, Bayesian MR. Store uncertainty (e.g., CV) when available; note tag loss/recovery protocols."@en ;
                             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                            rdfs:label "Mark-Recapture Analysis"@en ;
                             skos:broader gcdfo:EstimateMethod ;
                             skos:definition "Capture-recapture estimators (Petersen, Jolly-Seber, open/Bayesian models) applied to field marks/recoveries."@en ;
                             skos:inScheme gcdfo:EstimateMethodScheme ;
@@ -2657,6 +2730,7 @@ gcdfo:MarkRecaptureAssumptions rdf:type owl:NamedIndividual ,
                                         skos:Concept ;
                                rdfs:comment "Limits to Type 3 maximum"@en ;
                                rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                               rdfs:label "Mark-Recapture Assumptions"@en ;
                                skos:broader gcdfo:DowngradeCriteria ;
                                skos:definition "MR assumptions not evaluated"@en ;
                                skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -2670,6 +2744,7 @@ gcdfo:MarkRecaptureFieldProgram rdf:type owl:NamedIndividual ,
                                          skos:Concept ;
                                 rdfs:comment "Legacy methods: Tag Recovery"@en ;
                                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                rdfs:label "Mark-Recapture Field Program"@en ;
                                 skos:broader smn:EnumerationMethod ;
                                 skos:definition "Field program involving marking and subsequent recapture/recovery of tagged fish with documented assumptions and recovery coverage."@en ;
                                 skos:inScheme gcdfo:EnumerationMethodScheme ;
@@ -2683,6 +2758,7 @@ gcdfo:MethodUnknown rdf:type owl:NamedIndividual ,
                              skos:Concept ;
                     rdfs:comment "Limits to Type 5 maximum"@en ;
                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:label "Method Unknown/Inconsistent"@en ;
                     skos:broader gcdfo:DowngradeCriteria ;
                     skos:definition "Survey/analytical methods not adequately identified/consistent"@en ;
                     skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -2695,6 +2771,7 @@ gcdfo:MethodUnknown rdf:type owl:NamedIndividual ,
 gcdfo:MonitoringFieldWorkTheme rdf:type owl:NamedIndividual ,
                                         skos:Concept ;
                                rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                               rdfs:label "Monitoring and Field Work"@en ;
                                skos:definition "Field observations, sampling protocols, survey events, gear, and measurement methods used to collect salmon data."@en ;
                                skos:inScheme gcdfo:ThemeScheme ;
                                skos:prefLabel "Monitoring and Field Work"@en ;
@@ -2706,6 +2783,7 @@ gcdfo:NumberOfVisits rdf:type owl:NamedIndividual ,
                               skos:Concept ;
                      rdfs:comment "Limits to Type 4 maximum"@en ;
                      rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                     rdfs:label "Number of Visits"@en ;
                      skos:broader gcdfo:DowngradeCriteria ;
                      skos:definition "Insufficient number of survey visits"@en ;
                      skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -2718,6 +2796,7 @@ gcdfo:NumberOfVisits rdf:type owl:NamedIndividual ,
 gcdfo:OceanAgeDimension rdf:type owl:NamedIndividual ,
                                  skos:Concept ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "Ocean age dimension"@en ;
                         skos:altLabel "Marine age dimension"@en ;
                         skos:broader gcdfo:AgeDimension ;
                         skos:definition "Age value represents years spent in the marine environment."@en ;
@@ -2731,6 +2810,7 @@ gcdfo:PeakCountAnalysis rdf:type owl:NamedIndividual ,
                                  skos:Concept ;
                         rdfs:comment "Legacy methods: Peak Live, Peak Live + Dead, Peak + Cumulative Dead, Cumulative New"@en ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "Peak Count Analysis"@en ;
                         skos:broader gcdfo:EstimateMethod ;
                         skos:definition "Uses the peak survey (live ± dead variants) as the season estimate/index."@en ;
                         skos:inScheme gcdfo:EstimateMethodScheme ;
@@ -2747,6 +2827,7 @@ gcdfo:PercentChangeMetric rdf:type owl:NamedIndividual ,
                           <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004."@en ;
                           dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf> ;
                           rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                          rdfs:label "Percent change metric"@en ;
                           skos:altLabel "Rapid-status percent change metric"@en ;
                           skos:broader gcdfo:RapidStatusMetric ;
                           skos:definition "A short-term trend metric quantifying the percent (linear) change in spawner abundance over the most recent three generations."@en ;
@@ -2765,6 +2846,7 @@ gcdfo:PercentChangeMetricStatus rdf:type owl:NamedIndividual ,
                                          skos:Concept ;
                                 dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv> ;
                                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                rdfs:label "Percent change metric status"@en ;
                                 skos:altLabel "PercChangeCat"@en ;
                                 skos:broader gcdfo:WSPOutputVariable ;
                                 skos:definition "Categorical status derived from the percent-change metric using WSP status-zone thresholds."@en ;
@@ -2783,6 +2865,7 @@ gcdfo:PercentChangeMetricStatus rdf:type owl:NamedIndividual ,
 gcdfo:PolicyFramework rdf:type owl:NamedIndividual ,
                                skos:Concept ;
                       rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                      rdfs:label "Policy framework"@en ;
                       skos:definition "A policy, legal, or governance framework that defines how salmon status metrics, benchmarks, or reference points are set and interpreted."@en ;
                       skos:inScheme gcdfo:PolicyFrameworkScheme ;
                       skos:prefLabel "Policy framework"@en ;
@@ -2807,6 +2890,7 @@ gcdfo:PolicyFrameworkScheme rdf:type owl:NamedIndividual ,
 gcdfo:PolicyGovernanceTheme rdf:type owl:NamedIndividual ,
                                      skos:Concept ;
                             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                            rdfs:label "Policy, Governance, and Organizational Structure"@en ;
                             skos:definition "DFO policy frameworks, governance, regulations, and organizational structure relevant to salmon management."@en ;
                             skos:inScheme gcdfo:ThemeScheme ;
                             skos:prefLabel "Policy, Governance, and Organizational Structure"@en ;
@@ -2817,6 +2901,7 @@ gcdfo:PolicyGovernanceTheme rdf:type owl:NamedIndividual ,
 gcdfo:PrecautionaryApproach rdf:type owl:NamedIndividual ,
                                      skos:Concept ;
                             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                            rdfs:label "Precautionary Approach"@en ;
                             skos:altLabel "PA"@en ;
                             skos:broader gcdfo:PolicyFramework ;
                             skos:definition "DFO policy framework for applying precaution in fisheries decision-making, including use of reference points and stock status zones."@en ;
@@ -2832,6 +2917,7 @@ gcdfo:PrecisionAccuracy rdf:type owl:NamedIndividual ,
                                  skos:Concept ;
                         rdfs:comment "Downgrades by one level"@en ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "Precision/Accuracy"@en ;
                         skos:broader gcdfo:DowngradeCriteria ;
                         skos:definition "Precision/accuracy weaker than expected for type"@en ;
                         skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -2848,6 +2934,7 @@ gcdfo:ProbabilityDeclineBelowLowerBenchmarkMetric rdf:type owl:NamedIndividual ,
                                                   <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004."@en ;
                                                   dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf> ;
                                                   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                                  rdfs:label "Probability of decline below lower benchmark metric"@en ;
                                                   skos:broader gcdfo:RapidStatusMetric ;
                                                   skos:definition "A probability metric estimating the risk that spawner abundance will be below the lower benchmark, given uncertainty in benchmark estimates and/or abundance estimates, for a defined forecast or assessment horizon."@en ;
                                                   skos:inScheme gcdfo:RapidStatusMetricScheme ;
@@ -2865,6 +2952,7 @@ gcdfo:ProbabilityDeclineBelowLowerBenchmarkMetricStatus rdf:type owl:NamedIndivi
                                                                  skos:Concept ;
                                                         dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv> ;
                                                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                                        rdfs:label "Probability-of-decline-below-lower-benchmark metric status"@en ;
                                                         skos:altLabel "ProbDeclBelowLBMCat"@en ;
                                                         skos:broader gcdfo:WSPOutputVariable ;
                                                         skos:definition "Categorical status derived from the probability-of-decline-below-lower-benchmark metric."@en ;
@@ -2885,7 +2973,8 @@ gcdfo:RapidStatusConfidenceHigh rdf:type owl:NamedIndividual ,
                                          gcdfo:ConfidenceCategory ;
                                 <http://purl.obolibrary.org/obo/IAO_0000115> "Rapid status confidence category indicating that high-quality abundance metrics support the result."@en ;
                                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
-                                rdfs:label "High rapid-status confidence"@en ;
+                                rdfs:label "High confidence"@en ;
+                                skos:altLabel "High rapid-status confidence"@en ;
                                 skos:definition "Rapid status confidence category indicating that high-quality abundance metrics support the result."@en ;
                                 skos:inScheme gcdfo:RapidStatusConfidenceScheme ;
                                 skos:prefLabel "High confidence"@en ;
@@ -2899,7 +2988,8 @@ gcdfo:RapidStatusConfidenceLow rdf:type owl:NamedIndividual ,
                                         gcdfo:ConfidenceCategory ;
                                <http://purl.obolibrary.org/obo/IAO_0000115> "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone)."@en ;
                                rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
-                               rdfs:label "Low rapid-status confidence"@en ;
+                               rdfs:label "Low confidence"@en ;
+                               skos:altLabel "Low rapid-status confidence"@en ;
                                skos:definition "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone)."@en ;
                                skos:inScheme gcdfo:RapidStatusConfidenceScheme ;
                                skos:prefLabel "Low confidence"@en ;
@@ -2913,7 +3003,8 @@ gcdfo:RapidStatusConfidenceMedium rdf:type owl:NamedIndividual ,
                                            gcdfo:ConfidenceCategory ;
                                   <http://purl.obolibrary.org/obo/IAO_0000115> "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information."@en ;
                                   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
-                                  rdfs:label "Medium rapid-status confidence"@en ;
+                                  rdfs:label "Medium confidence"@en ;
+                                  skos:altLabel "Medium rapid-status confidence"@en ;
                                   skos:definition "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information."@en ;
                                   skos:inScheme gcdfo:RapidStatusConfidenceScheme ;
                                   skos:prefLabel "Medium confidence"@en ;
@@ -2937,6 +3028,7 @@ gcdfo:RapidStatusMetric rdf:type owl:NamedIndividual ,
                                  skos:Concept ;
                         gcdfo:usedProcedure gcdfo:WSPRapidStatusAssessmentMethod ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "Rapid status metric"@en ;
                         skos:definition "A compound variable concept representing a metric used by WSP rapid-status workflows."@en ;
                         skos:inScheme gcdfo:RapidStatusMetricScheme ;
                         skos:prefLabel "Rapid status metric"@en ;
@@ -2966,6 +3058,7 @@ gcdfo:RapidStatusScoreMetric rdf:type owl:NamedIndividual ,
                              <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2024. Rapid Status Approximations for Pacific Salmon Derived from Integrated Expert Assessments under DFO’s Wild Salmon Policy. CSAS Pacific Region Science Response 2024/004."@en ;
                              dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/41225260.pdf> ;
                              rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                             rdfs:label "Rapid status score metric"@en ;
                              skos:broader gcdfo:RapidStatusMetric ;
                              skos:definition "A numeric score produced by a rapid-status algorithm used to represent an ordered status outcome and/or decision-rule position."@en ;
                              skos:inScheme gcdfo:RapidStatusMetricScheme ;
@@ -2983,6 +3076,7 @@ gcdfo:ReachCoverage rdf:type owl:NamedIndividual ,
                              skos:Concept ;
                     rdfs:comment "Limits to Type 3 maximum"@en ;
                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:label "Reach Coverage"@en ;
                     skos:broader gcdfo:DowngradeCriteria ;
                     skos:definition "Insufficient reach coverage"@en ;
                     skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -2995,6 +3089,7 @@ gcdfo:ReachCoverage rdf:type owl:NamedIndividual ,
 gcdfo:RecruitStageContext rdf:type owl:NamedIndividual ,
                                    skos:Concept ;
                           rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                          rdfs:label "Recruit stage context"@en ;
                           skos:broader smn:MeasurementContext ;
                           skos:definition "Measurement context indicating values refer to recruits."@en ;
                           skos:inScheme smn:MeasurementContextScheme ;
@@ -3010,6 +3105,7 @@ gcdfo:RedZone rdf:type owl:NamedIndividual ,
               <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Wild Salmon Policy 2018-2022 Implementation Plan. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf."@en ;
               dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf> ;
               rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+              rdfs:label "Red zone"@en ;
               skos:definition "A Conservation Unit in the Red zone is undesirable because of the risk of extirpation, and the loss of ecological benefits and salmon production. Changes in status will trigger management actions that will vary depending on species, geographic regions, and cause of the decline."@en ;
               skos:inScheme gcdfo:IntegratedStatusOutcomeScheme ,
                             gcdfo:WSPBiologicalStatusZoneScheme ;
@@ -3024,6 +3120,7 @@ gcdfo:ReddCount rdf:type owl:NamedIndividual ,
                          skos:Concept ;
                 rdfs:comment "Legacy methods: Redd Counts"@en ;
                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                rdfs:label "Redd Count"@en ;
                 skos:broader smn:EnumerationMethod ;
                 skos:definition "Redd counts with documentation of detectability, timing, and reach coverage. Conversion to spawner estimates requires spawners-per-redd factors handled in analysis."@en ;
                 skos:inScheme gcdfo:EnumerationMethodScheme ;
@@ -3037,6 +3134,7 @@ gcdfo:ReddExpansionAnalysis rdf:type owl:NamedIndividual ,
                                      skos:Concept ;
                             rdfs:comment "Requires validated spawners-per-redd factor and documentation of detectability assumptions."@en ;
                             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                            rdfs:label "Redd Expansion Analysis"@en ;
                             skos:broader gcdfo:EstimateMethod ;
                             skos:definition "Converts redd counts to spawner estimates using spawners-per-redd expansion factors."@en ;
                             skos:inScheme gcdfo:EstimateMethodScheme ;
@@ -3050,6 +3148,7 @@ gcdfo:RelativeAbundanceMetricStatus rdf:type owl:NamedIndividual ,
                                              skos:Concept ;
                                     dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv> ;
                                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                    rdfs:label "Relative abundance metric status"@en ;
                                     skos:altLabel "RelAbdCat"@en ;
                                     skos:broader gcdfo:WSPOutputVariable ;
                                     skos:definition "Categorical status derived from the relative abundance metric benchmark ratio."@en ;
@@ -3071,6 +3170,7 @@ gcdfo:ReturnYear rdf:type owl:NamedIndividual ,
                  <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Pacific Salmon Glossary (Pacific Region web page)."@en ;
                  dcterms:source <https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html> ;
                  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                 rdfs:label "Return year"@en ;
                  skos:broader gcdfo:YearBasis ;
                  skos:definition "The calendar year in which adult salmon return from the ocean to freshwater systems (a year basis used to contextualize run/return-related measurements)."@en ;
                  skos:inScheme gcdfo:YearBasisScheme ;
@@ -3085,6 +3185,7 @@ gcdfo:ReviewQA rdf:type owl:NamedIndividual ,
                         skos:Concept ;
                rdfs:comment "Limits to Type 2 maximum"@en ;
                rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+               rdfs:label "Review/QA"@en ;
                skos:broader gcdfo:DowngradeCriteria ;
                skos:definition "Insufficient QA review of automated events"@en ;
                skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -3098,6 +3199,7 @@ gcdfo:RunCoverage rdf:type owl:NamedIndividual ,
                            skos:Concept ;
                   rdfs:comment "Limits to Type 2 maximum"@en ;
                   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                  rdfs:label "Run Coverage"@en ;
                   skos:broader gcdfo:DowngradeCriteria ;
                   skos:definition "Run-window coverage < 95% of season days"@en ;
                   skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -3110,6 +3212,7 @@ gcdfo:RunCoverage rdf:type owl:NamedIndividual ,
 gcdfo:SalmonEnhancementHatcheriesTheme rdf:type owl:NamedIndividual ,
                                                 skos:Concept ;
                                        rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                       rdfs:label "Salmon Enhancement and Hatcheries"@en ;
                                        skos:definition "Hatchery production, broodstock management, releases, and enhancement program practices for salmon."@en ;
                                        skos:inScheme gcdfo:ThemeScheme ;
                                        skos:prefLabel "Salmon Enhancement and Hatcheries"@en ;
@@ -3121,6 +3224,7 @@ gcdfo:Species rdf:type owl:NamedIndividual ,
                        skos:Concept ;
               dcterms:source <https://github.com/sos-program/Approved-WSP-Statuses/blob/master/OUTPUT/Retrospective_RapidStatus_Results_Approved_VariableDescriptions.csv> ;
               rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+              rdfs:label "Species"@en ;
               skos:broader gcdfo:WSPOutputVariable ;
               skos:definition "Species identity field used in canonical WSP outputs."@en ;
               skos:inScheme gcdfo:WSPOutputVariableScheme ;
@@ -3136,6 +3240,7 @@ gcdfo:Species rdf:type owl:NamedIndividual ,
 gcdfo:SpeciesAtRiskRecoveryTheme rdf:type owl:NamedIndividual ,
                                           skos:Concept ;
                                  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                 rdfs:label "Species at Risk and Recovery"@en ;
                                  skos:definition "COSEWIC/SARA recovery planning, critical habitat, threats, and status assessments for species of conservation concern."@en ;
                                  skos:inScheme gcdfo:ThemeScheme ;
                                  skos:prefLabel "Species at Risk and Recovery"@en ;
@@ -3146,6 +3251,7 @@ gcdfo:SpeciesAtRiskRecoveryTheme rdf:type owl:NamedIndividual ,
 gcdfo:StockAssessmentTheme rdf:type owl:NamedIndividual ,
                                     skos:Concept ;
                            rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                           rdfs:label "Stock Assessment"@en ;
                            skos:definition "Stock assessment models, benchmarks, status determinations, and performance metrics for salmon units."@en ;
                            skos:inScheme gcdfo:ThemeScheme ;
                            skos:prefLabel "Stock Assessment"@en ;
@@ -3180,6 +3286,7 @@ gcdfo:Timing rdf:type owl:NamedIndividual ,
                       skos:Concept ;
              rdfs:comment "Limits to Type 3 maximum"@en ;
              rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+             rdfs:label "Timing"@en ;
              skos:broader gcdfo:DowngradeCriteria ;
              skos:definition "Poor timing of surveys"@en ;
              skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -3192,6 +3299,7 @@ gcdfo:Timing rdf:type owl:NamedIndividual ,
 gcdfo:TotalAgeDimension rdf:type owl:NamedIndividual ,
                                  skos:Concept ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "Total age dimension"@en ;
                         skos:broader gcdfo:AgeDimension ;
                         skos:definition "Age value represents total age in years."@en ;
                         skos:inScheme gcdfo:AgeDimensionScheme ;
@@ -3204,6 +3312,7 @@ gcdfo:TrapCount rdf:type owl:NamedIndividual ,
                          skos:Concept ;
                 rdfs:comment "Legacy methods: Trap, Hatchery Passage Counting"@en ;
                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                rdfs:label "Trap Count"@en ;
                 skos:broader smn:EnumerationMethod ;
                 skos:definition "Trap-based counts from non-spanning traps with documented emptying schedule, efficiency measurements, and coverage information."@en ;
                 skos:inScheme gcdfo:EnumerationMethodScheme ;
@@ -3217,6 +3326,7 @@ gcdfo:TrapEfficiency rdf:type owl:NamedIndividual ,
                               skos:Concept ;
                      rdfs:comment "Limits to Type 3 maximum"@en ;
                      rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                     rdfs:label "Trap Efficiency"@en ;
                      skos:broader gcdfo:DowngradeCriteria ;
                      skos:definition "Trap efficiency not measured/validated"@en ;
                      skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -3230,6 +3340,7 @@ gcdfo:TrapModelAnalysis rdf:type owl:NamedIndividual ,
                                  skos:Concept ;
                         rdfs:comment "Requires documented trap efficiency measurements and cross-section coverage factors."@en ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "Trap Model Analysis"@en ;
                         skos:broader gcdfo:EstimateMethod ;
                         skos:definition "Trap-based counts adjusted with efficiency/coverage models to estimate total passage."@en ;
                         skos:inScheme gcdfo:EstimateMethodScheme ;
@@ -3242,6 +3353,7 @@ gcdfo:TrapModelAnalysis rdf:type owl:NamedIndividual ,
 gcdfo:Type1 rdf:type owl:NamedIndividual ,
                      skos:Concept ;
             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+            rdfs:label "Type-1, True Abundance, high resolution"@en ;
             skos:broader gcdfo:EstimateType ;
             skos:definition "Total, seasonal counts through fence or fishway; virtually no bypass. Simple, often single step analysis. Reliable resolution of between year differences >10% (in absolute units)."@en ;
             skos:inScheme gcdfo:EstimateTypeScheme ;
@@ -3254,6 +3366,7 @@ gcdfo:Type1 rdf:type owl:NamedIndividual ,
 gcdfo:Type2 rdf:type owl:NamedIndividual ,
                      skos:Concept ;
             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+            rdfs:label "Type-2, True Abundance, medium resolution"@en ;
             skos:broader gcdfo:EstimateType ;
             skos:definition "Indirect estimate of total spawner abundance with qualified accuracy and known precision (i.e., a variance estimate—an explicit quantitative measure of uncertainty around the estimate). Derived from high-effort, standardized methods (e.g., mark-recapture, serial counts for area under the curve) with documented analytical conversions (including interpolation/calibration as needed). Reported in absolute units (estimate ± variance). Reliable resolution of between-year differences >25% (in absolute units)."@en ;
             skos:inScheme gcdfo:EstimateTypeScheme ;
@@ -3266,6 +3379,7 @@ gcdfo:Type2 rdf:type owl:NamedIndividual ,
 gcdfo:Type3 rdf:type owl:NamedIndividual ,
                      skos:Concept ;
             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+            rdfs:label "Type-3, Relative Abundance, high resolution"@en ;
             skos:broader gcdfo:EstimateType ;
             skos:definition "Relative abundance index (i.e., not an absolute count) derived from moderate to high effort surveys (typically 3 or more site visits) using standardized methods applied consistently between and within years (e.g., equal-effort surveys executed by walk, swim, overflight). Accuracy and precision are not fully quantified (i.e., no explicit variance estimate), but are assumed stable enough for within-series comparisons. Reliable resolution of between-year differences >25% (in relative units)."@en ;
             skos:inScheme gcdfo:EstimateTypeScheme ;
@@ -3278,6 +3392,7 @@ gcdfo:Type3 rdf:type owl:NamedIndividual ,
 gcdfo:Type4 rdf:type owl:NamedIndividual ,
                      skos:Concept ;
             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+            rdfs:label "Type-4, Relative Abundance, medium resolution"@en ;
             skos:broader gcdfo:EstimateType ;
             skos:definition "Low to moderate effort (1-4 trips), known survey method. Simple analysis by known methods. Reliable resolution of between year differences >200% (in relative units)."@en ;
             skos:inScheme gcdfo:EstimateTypeScheme ;
@@ -3290,6 +3405,7 @@ gcdfo:Type4 rdf:type owl:NamedIndividual ,
 gcdfo:Type5 rdf:type owl:NamedIndividual ,
                      skos:Concept ;
             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+            rdfs:label "Type-5, Relative Abundance, low resolution"@en ;
             skos:broader gcdfo:EstimateType ;
             skos:definition "Low effort (e.g. 1 trip), use of vaguely defined, inconsistent or poorly executed methods. Unknown to ill defined; inconsistent or poorly executed. Uncertain numeric comparisons, but high reliability for presence or absence."@en ;
             skos:inScheme gcdfo:EstimateTypeScheme ;
@@ -3302,6 +3418,7 @@ gcdfo:Type5 rdf:type owl:NamedIndividual ,
 gcdfo:Type6 rdf:type owl:NamedIndividual ,
                      skos:Concept ;
             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+            rdfs:label "Type-6, Presence or Absence"@en ;
             skos:altLabel "Presence/Not Detected"@en ;
             skos:broader gcdfo:EstimateType ;
             skos:definition "Non-numeric, year-specific record of presence/not detected (i.e., present/absent without estimating a count), tied to an explicit time and location, with reliable species identification. Underlying field methods may be highly variable; analysis is not required."@en ;
@@ -3318,6 +3435,7 @@ gcdfo:UnrankedIndexQuality rdf:type owl:NamedIndividual ,
                            <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2020. 2020 summary of abundance data for Chinook salmon (Oncorhynchus tshawytscha) in southern British Columbia, Canada (nuSEDS Estimate Classification includes 'Unknown: no quality rating')."@en ;
                            dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/Library/40890041.pdf> ;
                            rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                           rdfs:label "Unranked index quality"@en ;
                            skos:broader gcdfo:EstimateType ;
                            skos:definition "A data quality category indicating that no spawner-abundance estimate classification / index quality rating was assigned for the record (i.e., an 'Unknown' estimate classification with no quality rating)."@en ;
                            skos:inScheme gcdfo:EstimateTypeScheme ;
@@ -3330,6 +3448,7 @@ gcdfo:UnrankedIndexQuality rdf:type owl:NamedIndividual ,
 gcdfo:UpperBenchmark rdf:type owl:NamedIndividual ,
                               skos:Concept ;
                      rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                     rdfs:label "Upper benchmark"@en ;
                      skos:definition "An upper-threshold benchmark value, typically delineating the boundary between Amber and Green status zones."@en ;
                      skos:inScheme gcdfo:BenchmarkLevelScheme ;
                      skos:prefLabel "Upper benchmark"@en ;
@@ -3342,6 +3461,7 @@ gcdfo:Uptime rdf:type owl:NamedIndividual ,
                       skos:Concept ;
              rdfs:comment "Limits to Type 2 maximum"@en ;
              rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+             rdfs:label "Uptime"@en ;
              skos:broader gcdfo:DowngradeCriteria ;
              skos:definition "Counting/device uptime < 95% (or <90% with interpolation)"@en ;
              skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -3355,6 +3475,7 @@ gcdfo:Visibility rdf:type owl:NamedIndividual ,
                           skos:Concept ;
                  rdfs:comment "Limits to Type 3 maximum"@en ;
                  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                 rdfs:label "Visibility"@en ;
                  skos:broader gcdfo:DowngradeCriteria ;
                  skos:definition "Poor visibility conditions"@en ;
                  skos:inScheme gcdfo:DowngradeCriteriaScheme ;
@@ -3368,6 +3489,7 @@ gcdfo:VisualGroundCount rdf:type owl:NamedIndividual ,
                                  skos:Concept ;
                         rdfs:comment "Legacy methods: Stream Walk, Ground count, Bank Walk"@en ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "Visual Ground Count"@en ;
                         skos:broader smn:EnumerationMethod ;
                         skos:definition "Visual surveys conducted by stream/bank walk with documented visit schedule, reach coverage, timing, and visibility conditions."@en ;
                         skos:inScheme gcdfo:EnumerationMethodScheme ;
@@ -3381,6 +3503,7 @@ gcdfo:VisualSnorkelCount rdf:type owl:NamedIndividual ,
                                   skos:Concept ;
                          rdfs:comment "Legacy methods: Snorkel, Snorkel Swim"@en ;
                          rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                         rdfs:label "Visual Snorkel Count"@en ;
                          skos:broader smn:EnumerationMethod ;
                          skos:definition "Two or more trained snorkelers conduct standardized passes within defined segments, tallying live/dead by species. Field forms capture visibility class, segment boundaries, and repeat-visit schedule; counts are aggregated across observers/passes."@en ;
                          skos:inScheme gcdfo:EnumerationMethodScheme ;
@@ -3410,6 +3533,7 @@ gcdfo:WSPBiologicalStatusZoneScheme rdf:type owl:NamedIndividual ,
 gcdfo:WSPOutputVariable rdf:type owl:NamedIndividual ,
                                  skos:Concept ;
                         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:label "WSP output variable"@en ;
                         skos:definition "A canonical variable field used in approved Wild Salmon Policy output tables."@en ;
                         skos:inScheme gcdfo:WSPOutputVariableScheme ;
                         skos:prefLabel "WSP output variable"@en ;
@@ -3436,6 +3560,7 @@ gcdfo:WSPRapidStatusAssessmentMethod rdf:type owl:NamedIndividual ,
                                      <http://purl.obolibrary.org/obo/IAO_0000119> "Pestal, G., MacDonald, B.L., Grant, S.C.H., and Holt, C.A. 2023. State of the salmon: rapid status assessment approach for Pacific salmon under Canada's Wild Salmon Policy. Canadian Technical Report of Fisheries and Aquatic Sciences 3570."@en ;
                                      dcterms:source <https://publications.gc.ca/site/eng/9.928944/publication.html> ;
                                      rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                     rdfs:label "WSP rapid-status assessment method"@en ;
                                      skos:altLabel "WSP rapid status method"@en ;
                                      skos:broader gcdfo:EstimateMethod ;
                                      skos:definition "The analytical method used to produce rapid-status metrics under the Wild Salmon Policy rapid-status approach."@en ;
@@ -3450,6 +3575,7 @@ gcdfo:WSPRapidStatusAssessmentMethod rdf:type owl:NamedIndividual ,
 gcdfo:WildSalmonPolicy rdf:type owl:NamedIndividual ,
                                 skos:Concept ;
                        rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                       rdfs:label "Wild Salmon Policy"@en ;
                        skos:altLabel "WSP"@en ;
                        skos:broader gcdfo:PolicyFramework ;
                        skos:definition "Canada's Wild Salmon Policy framework for conserving and managing wild Pacific salmon, including integrated status assessments and biological benchmarks for Conservation Units."@en ;
@@ -3464,6 +3590,7 @@ gcdfo:WildSalmonPolicy rdf:type owl:NamedIndividual ,
 gcdfo:WildSalmonPolicyTheme rdf:type owl:NamedIndividual ,
                                      skos:Concept ;
                             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                            rdfs:label "Wild Salmon Policy"@en ;
                             skos:definition "Conservation Unit based stock assessment methods, metrics, and metadata"@en ;
                             skos:inScheme gcdfo:ThemeScheme ;
                             skos:prefLabel "Wild Salmon Policy"@en ;
@@ -3475,6 +3602,7 @@ gcdfo:YearBasis rdf:type owl:NamedIndividual ,
                          skos:Concept ;
                 <http://purl.obolibrary.org/obo/IAO_0000115> "A year-based temporal reference used to contextualize measurements or rates (e.g., brood year, catch year, or return year)."@en ;
                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                rdfs:label "Year basis"@en ;
                 skos:definition "A year-based temporal reference used to contextualize measurements or rates (e.g., brood year, catch year, or return year)."@en ;
                 skos:inScheme gcdfo:YearBasisScheme ;
                 skos:prefLabel "Year basis"@en ;
@@ -3496,6 +3624,7 @@ gcdfo:YearBasisScheme rdf:type owl:NamedIndividual ,
 ###  https://w3id.org/smn/CatchContext
 smn:CatchContext rdf:type skos:Concept ;
                  rdfs:isDefinedBy <https://w3id.org/smn> ;
+                 rdfs:label "Catch context"@en ;
                  skos:broader smn:MeasurementContext ;
                  skos:definition "Measurement context indicating values refer to fishery catch."@en ;
                  skos:inScheme smn:MeasurementContextScheme ;
@@ -3507,6 +3636,7 @@ smn:CatchContext rdf:type skos:Concept ;
 smn:EnumerationMethod rdf:type owl:NamedIndividual ,
                                skos:Concept ;
                       rdfs:isDefinedBy <https://w3id.org/smn> ;
+                      rdfs:label "Enumeration Method"@en ;
                       skos:definition "A method used to enumerate or count salmon in the field"@en ;
                       skos:inScheme gcdfo:EnumerationMethodScheme ;
                       skos:prefLabel "Enumeration Method"@en ;
@@ -3520,6 +3650,7 @@ smn:HatcheryOrigin rdf:type skos:Concept ;
                    <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2018. Review of genetically based targets for enhanced contributions to Canadian Pacific Chinook Salmon populations. DFO Canadian Science Advisory Secretariat Science Advisory Report 2018/001 (Erratum: October 2023)."@en ;
                    dcterms:source <https://www.dfo-mpo.gc.ca/csas-sccs/Publications/SAR-AS/2018/2018_001-eng.html> ;
                    rdfs:isDefinedBy <https://w3id.org/smn> ;
+                   rdfs:label "Hatchery-origin"@en ;
                    skos:broader smn:SalmonOrigin ;
                    skos:definition "Individuals that were born or reared in a hatchery facility."@en ;
                    skos:inScheme smn:SalmonOriginScheme ;
@@ -3532,6 +3663,7 @@ smn:HatcheryOrigin rdf:type skos:Concept ;
 ###  https://w3id.org/smn/InRiverPhase
 smn:InRiverPhase rdf:type skos:Concept ;
                  rdfs:isDefinedBy <https://w3id.org/smn> ;
+                 rdfs:label "In-river phase"@en ;
                  skos:altLabel "Freshwater phase"@en ;
                  skos:broader smn:LifePhase ;
                  skos:definition "Freshwater in-river phase (migration and/or residence) outside the marine environment."@en ;
@@ -3543,6 +3675,7 @@ smn:InRiverPhase rdf:type skos:Concept ;
 ###  https://w3id.org/smn/LifePhase
 smn:LifePhase rdf:type skos:Concept ;
               rdfs:isDefinedBy <https://w3id.org/smn> ;
+              rdfs:label "Life phase"@en ;
               skos:definition "A phase or segment used to stratify salmon measurements by where or when they apply (e.g., ocean phase, terminal phase)."@en ;
               skos:inScheme smn:LifePhaseScheme ;
               skos:prefLabel "Life phase"@en ;
@@ -3561,6 +3694,7 @@ smn:LifePhaseScheme rdf:type skos:ConceptScheme ;
 ###  https://w3id.org/smn/MainstemPhase
 smn:MainstemPhase rdf:type skos:Concept ;
                   rdfs:isDefinedBy <https://w3id.org/smn> ;
+                  rdfs:label "Mainstem phase"@en ;
                   skos:broader smn:LifePhase ;
                   skos:definition "Freshwater mainstem migration phase in a river system (often corresponding to mainstem in-river fisheries or monitoring segments)."@en ;
                   skos:inScheme smn:LifePhaseScheme ;
@@ -3571,6 +3705,7 @@ smn:MainstemPhase rdf:type skos:Concept ;
 ###  https://w3id.org/smn/MeasurementContext
 smn:MeasurementContext rdf:type skos:Concept ;
                        rdfs:isDefinedBy <https://w3id.org/smn> ;
+                       rdfs:label "Measurement context"@en ;
                        skos:definition "A context qualifier used to disambiguate the interpretation of a measurement column."@en ;
                        skos:inScheme smn:MeasurementContextScheme ;
                        skos:prefLabel "Measurement context"@en ;
@@ -3593,6 +3728,7 @@ smn:NaturalOrigin rdf:type skos:Concept ;
                   <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2018. Review of genetically based targets for enhanced contributions to Canadian Pacific Chinook Salmon populations. DFO Canadian Science Advisory Secretariat Science Advisory Report 2018/001 (Erratum: October 2023)."@en ;
                   dcterms:source <https://www.dfo-mpo.gc.ca/csas-sccs/Publications/SAR-AS/2018/2018_001-eng.html> ;
                   rdfs:isDefinedBy <https://w3id.org/smn> ;
+                  rdfs:label "Natural-origin"@en ;
                   skos:broader smn:SalmonOrigin ;
                   skos:definition "Individuals that are born and reared in the wild (natural environment)."@en ;
                   skos:inScheme smn:SalmonOriginScheme ;
@@ -3605,6 +3741,7 @@ smn:NaturalOrigin rdf:type skos:Concept ;
 ###  https://w3id.org/smn/OceanPhase
 smn:OceanPhase rdf:type skos:Concept ;
                rdfs:isDefinedBy <https://w3id.org/smn> ;
+               rdfs:label "Ocean phase"@en ;
                skos:altLabel "Marine phase"@en ;
                skos:broader smn:LifePhase ;
                skos:definition "Phase of the salmon life cycle or assessment period occurring in the marine environment."@en ;
@@ -3616,6 +3753,7 @@ smn:OceanPhase rdf:type skos:Concept ;
 ###  https://w3id.org/smn/RunContext
 smn:RunContext rdf:type skos:Concept ;
                rdfs:isDefinedBy <https://w3id.org/smn> ;
+               rdfs:label "Run context"@en ;
                skos:broader smn:MeasurementContext ;
                skos:definition "Measurement context indicating values refer to run size or returning run composition."@en ;
                skos:inScheme smn:MeasurementContextScheme ;
@@ -3626,6 +3764,7 @@ smn:RunContext rdf:type skos:Concept ;
 ###  https://w3id.org/smn/SalmonOrigin
 smn:SalmonOrigin rdf:type skos:Concept ;
                  rdfs:isDefinedBy <https://w3id.org/smn> ;
+                 rdfs:label "Salmon origin"@en ;
                  skos:definition "Origin category describing whether salmon are naturally produced, hatchery produced, or mixed-origin."@en ;
                  skos:inScheme smn:SalmonOriginScheme ;
                  skos:prefLabel "Salmon origin"@en ;
@@ -3647,6 +3786,7 @@ smn:SalmonOriginScheme rdf:type skos:ConceptScheme ;
 ###  https://w3id.org/smn/SpawnerStageContext
 smn:SpawnerStageContext rdf:type skos:Concept ;
                         rdfs:isDefinedBy <https://w3id.org/smn> ;
+                        rdfs:label "Spawner stage context"@en ;
                         skos:broader smn:MeasurementContext ;
                         skos:definition "Measurement context indicating values refer to spawners or spawning-stage fish."@en ;
                         skos:inScheme smn:MeasurementContextScheme ;
@@ -3657,6 +3797,7 @@ smn:SpawnerStageContext rdf:type skos:Concept ;
 ###  https://w3id.org/smn/SurvivalOrMortalityContext
 smn:SurvivalOrMortalityContext rdf:type skos:Concept ;
                                rdfs:isDefinedBy <https://w3id.org/smn> ;
+                               rdfs:label "Survival or mortality context"@en ;
                                skos:broader smn:MeasurementContext ;
                                skos:definition "Measurement context indicating values represent survival, mortality, or related rates."@en ;
                                skos:inScheme smn:MeasurementContextScheme ;
@@ -3667,6 +3808,7 @@ smn:SurvivalOrMortalityContext rdf:type skos:Concept ;
 ###  https://w3id.org/smn/TerminalPhase
 smn:TerminalPhase rdf:type skos:Concept ;
                   rdfs:isDefinedBy <https://w3id.org/smn> ;
+                  rdfs:label "Terminal phase"@en ;
                   skos:broader smn:LifePhase ;
                   skos:definition "Phase occurring in terminal areas near river mouths or spawning areas (often including terminal fisheries and local migration to spawning sites)."@en ;
                   skos:inScheme smn:LifePhaseScheme ;
@@ -3679,6 +3821,7 @@ smn:TerminalPhase rdf:type skos:Concept ;
 #################################################################
 
 gcdfo:ConfidenceCategory rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                         rdfs:label "Confidence category"@en ;
                          skos:definition "Categorical confidence rating (High, Medium, Low) for stock assessment metrics."@en ;
                          skos:inScheme gcdfo:RapidStatusConfidenceScheme ;
                          skos:prefLabel "Confidence category"@en ;
@@ -3687,6 +3830,7 @@ gcdfo:ConfidenceCategory rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
 
 
 gcdfo:IntegratedStatusOutcome rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                              rdfs:label "Integrated status outcome"@en ;
                               skos:definition "Outcome category assigned by integrated WSP status workflows for a Conservation Unit."@en ;
                               skos:inScheme gcdfo:IntegratedStatusOutcomeScheme ;
                               skos:prefLabel "Integrated status outcome"@en ;
@@ -3697,6 +3841,7 @@ gcdfo:IntegratedStatusOutcome rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
 gcdfo:WSPBiologicalStatusZone <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Wild Salmon Policy 2018-2022 Implementation Plan. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf."@en ;
                               dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf> ;
                               rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                              rdfs:label "Wild Salmon Policy biological status zone"@en ;
                               skos:definition "The biological status of a Conservation Unit (CU) will normally be based on the abundance and distribution of spawners in the unit, or proxies thereof. For each CU, higher and lower benchmarks will be defined that will delimit three status zones: Green, Amber, and Red. As spawner abundance decreases, a CU moves towards the lower status zone, and the extent of management intervention for conservation purposes will increase."@en ;
                               skos:inScheme gcdfo:WSPBiologicalStatusZoneScheme ;
                               skos:prefLabel "Wild Salmon Policy biological status zone"@en ;

--- a/docs/gcdfo.ttl
+++ b/docs/gcdfo.ttl
@@ -509,7 +509,7 @@ smn:demeOf rdf:type owl:ObjectProperty ;
            rdfs:domain smn:Deme ;
            rdfs:range smn:Population ;
            <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a deme to the population it belongs to."@en ;
-           rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+           rdfs:isDefinedBy <https://w3id.org/smn> ;
            rdfs:label "deme of"@en ;
            gcdfo:theme gcdfo:GeneticsStockCompositionTheme ,
                        gcdfo:WildSalmonPolicyTheme .
@@ -520,7 +520,7 @@ smn:hasDeme rdf:type owl:ObjectProperty ;
             rdfs:domain smn:Population ;
             rdfs:range smn:Deme ;
             <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a population to one of its constituent demes."@en ;
-            rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+            rdfs:isDefinedBy <https://w3id.org/smn> ;
             rdfs:label "has deme"@en ;
             gcdfo:theme gcdfo:GeneticsStockCompositionTheme ,
                         gcdfo:WildSalmonPolicyTheme .
@@ -541,7 +541,7 @@ smn:hasPopulation rdf:type owl:ObjectProperty ;
                   rdfs:range smn:Population ;
                   <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a Conservation Unit to one of its constituent populations."@en ;
                   rdfs:comment "DFO profile note: within this ontology, `smn:hasPopulation` is primarily used for ConservationUnit-to-Population composition."@en ;
-                  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                  rdfs:isDefinedBy <https://w3id.org/smn> ;
                   rdfs:label "has population"@en ;
                   gcdfo:theme gcdfo:StockAssessmentTheme ,
                               gcdfo:WildSalmonPolicyTheme .
@@ -557,7 +557,7 @@ smn:populationOf rdf:type owl:ObjectProperty ;
                  rdfs:range gcdfo:ConservationUnit ;
                  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a population to the Conservation Unit it belongs to."@en ;
                  rdfs:comment "DFO profile note: within this ontology, `smn:populationOf` is primarily used for Population-to-ConservationUnit composition."@en ;
-                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                 rdfs:isDefinedBy <https://w3id.org/smn> ;
                  rdfs:label "population of"@en ;
                  gcdfo:theme gcdfo:StockAssessmentTheme ,
                              gcdfo:WildSalmonPolicyTheme .
@@ -1271,7 +1271,7 @@ gcdfo:WSPRapidStatusAlgorithmThreshold rdf:type owl:Class ;
 smn:Deme rdf:type owl:Class ;
          rdfs:subClassOf dwc:Organism ;
          <http://purl.obolibrary.org/obo/IAO_0000115> "A local interbreeding group of organisms within a species. In salmon, a deme typically corresponds to a spawning population at a specific site. Demes are the finest biological unit and make up populations."@en ;
-         rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+         rdfs:isDefinedBy <https://w3id.org/smn> ;
          rdfs:label "Deme"@en ;
          gcdfo:theme gcdfo:GeneticsStockCompositionTheme ,
                      gcdfo:StockAssessmentTheme ,
@@ -1284,7 +1284,7 @@ smn:Escapement rdf:type owl:Class ;
                <http://purl.obolibrary.org/obo/IAO_0000115> "The number of mature salmon that pass through (or escape) fisheries and return to fresh water to spawn."@en ;
                <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2005. Canada's Policy for Conservation of Wild Pacific Salmon. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/315577.pdf."@en ;
                dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/315577.pdf> ;
-               rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+               rdfs:isDefinedBy <https://w3id.org/smn> ;
                rdfs:label "Escapement"@en ;
                gcdfo:theme gcdfo:MonitoringFieldWorkTheme ,
                            gcdfo:StockAssessmentTheme .
@@ -1295,7 +1295,7 @@ smn:EscapementMeasurement rdf:type owl:Class ;
                           rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000109> ,
                                           sosa:Result ;
                           <http://purl.obolibrary.org/obo/IAO_0000115> "A measurement or estimate of escapement tied to a stock and a survey event."@en ;
-                          rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                          rdfs:isDefinedBy <https://w3id.org/smn> ;
                           rdfs:label "Escapement measurement"@en ;
                           gcdfo:theme gcdfo:MonitoringFieldWorkTheme ,
                                       gcdfo:StockAssessmentTheme .
@@ -1305,7 +1305,7 @@ smn:EscapementMeasurement rdf:type owl:Class ;
 smn:EscapementSurveyEvent rdf:type owl:Class ;
                           rdfs:subClassOf smn:SurveyEvent ;
                           <http://purl.obolibrary.org/obo/IAO_0000115> "A survey event specifically for estimating escapement."@en ;
-                          rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                          rdfs:isDefinedBy <https://w3id.org/smn> ;
                           rdfs:label "Escapement Survey Event"@en ;
                           skos:prefLabel "Escapement Survey Event"@en ;
                           gcdfo:theme gcdfo:MonitoringFieldWorkTheme ,
@@ -1318,7 +1318,7 @@ smn:ExploitationRate rdf:type owl:Class ;
                      <http://purl.obolibrary.org/obo/IAO_0000115> "A fishing mortality rate expressed as the proportion of the total return removed by fishing over a specified assessment period."@en ;
                      <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Pacific Salmon - Glossary (Pacific Region). https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html."@en ;
                      dcterms:source <https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html> ;
-                     rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                     rdfs:isDefinedBy <https://w3id.org/smn> ;
                      rdfs:label "Exploitation rate"@en ;
                      gcdfo:theme gcdfo:FisheriesManagementTheme ,
                                  gcdfo:StockAssessmentTheme .
@@ -1329,7 +1329,7 @@ smn:FisheriesReferencePointLower rdf:type owl:Class ;
                                  rdfs:subClassOf smn:LimitReferencePoint ;
                                  <http://purl.obolibrary.org/obo/IAO_0000115> "A lower fisheries-management reference point defined for Stock Management Units (SMUs) and related fishery decision frameworks. It may be informed by Conservation Unit (CU) lower biological benchmarks, but is not identical to CU-level lower biological benchmarks used to delineate Wild Salmon Policy biological status zones."@en ;
                                  <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. (2022). Methodologies and Guidelines for Defining Limit Reference Points for Pacific Salmon. DFO Can. Sci. Advis. Sec. Sci. Advis. Rep. 2022/030. (Erratum: December 2022)."@en ;
-                                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                 rdfs:isDefinedBy <https://w3id.org/smn> ;
                                  rdfs:label "Fisheries Reference Point - Lower"@en ;
                                  skos:altLabel "FRP-L"@en ;
                                  gcdfo:theme gcdfo:FisheriesManagementTheme ,
@@ -1342,7 +1342,7 @@ smn:IndicatorRiver rdf:type owl:Class ;
                    rdfs:subClassOf smn:ReportingOrManagementStratum ;
                    <http://purl.obolibrary.org/obo/IAO_0000115> "A reporting and assessment stratum identifying monitored indicator streams that provide representative indices of spawner abundance for nearby streams."@en ;
                    dcterms:source <https://www.salmonexplorer.ca/methods/glossary.html> ;
-                   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                   rdfs:isDefinedBy <https://w3id.org/smn> ;
                    rdfs:label "Indicator river"@en ;
                    skos:altLabel "Indicator stream"@en ;
                    gcdfo:theme gcdfo:MonitoringFieldWorkTheme ,
@@ -1356,7 +1356,7 @@ smn:LimitReferencePoint rdf:type owl:Class ;
                         <http://purl.obolibrary.org/obo/IAO_0000115> "A fish stock experiencing serious harm may be depleted to the point where it has impaired productivity or reproductive capacity. As a result, the stock would be less resilient to fishing and could not easily rebuild. Serious harm may be irreversible, or only slowly reversible over the long-term, and can be due to fishing, other human-induced impacts, or natural causes. Under the Precautionary Approach policy and the Fish Stocks Provisions (FSPs), breaching the LRP is a trigger for a rebuilding plan."@en ;
                         <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Introduction to Stock Assessment - Glossary. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html."@en ;
                         dcterms:source <https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html> ;
-                        rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:isDefinedBy <https://w3id.org/smn> ;
                         rdfs:label "Limit reference point"@en ;
                         skos:altLabel "LRP"@en ;
                         gcdfo:theme gcdfo:FisheriesManagementTheme ,
@@ -1371,7 +1371,7 @@ smn:MetricBenchmark rdf:type owl:Class ;
                     <http://purl.obolibrary.org/obo/IAO_0000119> "Pestal, G., MacDonald, B.L., Grant, S.C.H., and Holt, C.A. 2023. State of the salmon: rapid status assessment approach for Pacific salmon under Canada's Wild Salmon Policy. Canadian Technical Report of Fisheries and Aquatic Sciences 3570."@en ;
                     dcterms:source <https://publications.gc.ca/site/eng/9.928944/publication.html> ;
                     rdfs:comment "DFO profile note: this ontology applies `smn:MetricBenchmark` in Wild Salmon Policy status-zone workflows."@en ;
-                    rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:isDefinedBy <https://w3id.org/smn> ;
                     rdfs:label "Metric benchmark"@en ;
                     gcdfo:theme gcdfo:StockAssessmentTheme ,
                                 gcdfo:WildSalmonPolicyTheme .
@@ -1381,7 +1381,7 @@ smn:MetricBenchmark rdf:type owl:Class ;
 smn:ObservedRateOrAbundance rdf:type owl:Class ;
                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000109> ;
                             <http://purl.obolibrary.org/obo/IAO_0000115> "A measurement datum representing an empirically observed rate, count, or abundance derived from monitoring or survey data."@en ;
-                            rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                            rdfs:isDefinedBy <https://w3id.org/smn> ;
                             rdfs:label "Observed rate or abundance"@en ;
                             gcdfo:theme gcdfo:DataModelProvenanceTheme ,
                                         gcdfo:StockAssessmentTheme .
@@ -1392,7 +1392,7 @@ smn:Population rdf:type owl:Class ;
                rdfs:subClassOf dwc:Organism ;
                <http://purl.obolibrary.org/obo/IAO_0000115> "A group of organisms of the same species occupying a defined area that interbreed and share a gene pool. In salmon, populations are composed of one or more demes and form the biological basis for Conservation Units."@en ;
                rdfs:comment "DFO profile note: this ontology applies `smn:Population` in Wild Salmon Policy / Conservation Unit contexts."@en ;
-               rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+               rdfs:isDefinedBy <https://w3id.org/smn> ;
                rdfs:label "Population"@en ;
                gcdfo:theme gcdfo:GeneticsStockCompositionTheme ,
                            gcdfo:StockAssessmentTheme ,
@@ -1406,7 +1406,7 @@ smn:ReferencePoint rdf:type owl:Class ;
                    <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Introduction to Stock Assessment - Glossary. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html."@en ;
                    dcterms:source <https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html> ;
                    rdfs:comment "DFO profile note: this ontology applies `smn:ReferencePoint` in DFO fisheries-management and assessment workflows."@en ;
-                   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                   rdfs:isDefinedBy <https://w3id.org/smn> ;
                    rdfs:label "Reference point"@en ;
                    gcdfo:theme gcdfo:FisheriesManagementTheme ,
                                gcdfo:PolicyGovernanceTheme ,
@@ -1417,7 +1417,7 @@ smn:ReferencePoint rdf:type owl:Class ;
 smn:ReportingOrManagementStratum rdf:type owl:Class ;
                                  rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000030> ;
                                  <http://purl.obolibrary.org/obo/IAO_0000115> "An information-defined grouping of fish populations used for reporting, conservation assessment, or management purposes. Examples include Conservation Units (CUs), Stock Management Units (MUs), and Designatable Units (DUs)."@en ;
-                                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                 rdfs:isDefinedBy <https://w3id.org/smn> ;
                                  rdfs:label "Reporting or management stratum"@en ;
                                  gcdfo:theme gcdfo:PolicyGovernanceTheme ,
                                              gcdfo:StockAssessmentTheme .
@@ -1429,7 +1429,7 @@ smn:Stock rdf:type owl:Class ;
           <http://purl.obolibrary.org/obo/IAO_0000115> "An operationally-defined grouping of salmon used for assessment and management purposes. A stock is a management unit or reporting stratum, not a biological organism."@en ;
           <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Introduction to Stock Assessment - Glossary. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html."@en ;
           dcterms:source <https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html> ;
-          rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+          rdfs:isDefinedBy <https://w3id.org/smn> ;
           rdfs:label "Stock"@en ;
           skos:altLabel "Fish stock"@en ;
           gcdfo:theme gcdfo:FisheriesManagementTheme ,
@@ -1443,7 +1443,7 @@ smn:StockAssessment rdf:type owl:Class ;
                     <http://purl.obolibrary.org/obo/IAO_0000115> "The scientific process of analyzing data to estimate the abundance and productivity of fish stocks in the past, present, and future. It is the backbone of successful science-based fisheries management"@en ;
                     <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Introduction to Stock Assessment. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/module-1/09-eng.html."@en ;
                     dcterms:source <https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/module-1/09-eng.html> ;
-                    rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:isDefinedBy <https://w3id.org/smn> ;
                     rdfs:label "Stock assessment"@en ;
                     gcdfo:theme gcdfo:StockAssessmentTheme .
 
@@ -1456,7 +1456,7 @@ smn:SurveyEvent rdf:type owl:Class ;
                 <http://purl.obolibrary.org/obo/IAO_0000115> "A field event that collects information about key fish stocks to track their status, and track progress to implement fishery policies and measures for these stocks."@en ;
                 <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. About the Sustainability Survey for Fisheries. https://www.dfo-mpo.gc.ca/reports-rapports/regs/sff-cpd/survey-sondage/about-propos-en.html."@en ;
                 dcterms:source <https://www.dfo-mpo.gc.ca/reports-rapports/regs/sff-cpd/survey-sondage/about-propos-en.html> ;
-                rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                rdfs:isDefinedBy <https://w3id.org/smn> ;
                 rdfs:label "Survey event"@en ;
                 gcdfo:theme gcdfo:MonitoringFieldWorkTheme ,
                             gcdfo:StockAssessmentTheme .
@@ -1466,7 +1466,7 @@ smn:SurveyEvent rdf:type owl:Class ;
 smn:TargetOrLimitRateOrAbundance rdf:type owl:Class ;
                                  rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000109> ;
                                  <http://purl.obolibrary.org/obo/IAO_0000115> "A value specification representing a policy- or model-defined target or limit, such as TAC or UMSY."@en ;
-                                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                                 rdfs:isDefinedBy <https://w3id.org/smn> ;
                                  rdfs:label "Target or limit rate or abundance"@en ;
                                  gcdfo:theme gcdfo:DataModelProvenanceTheme ,
                                              gcdfo:PolicyGovernanceTheme ,
@@ -1477,7 +1477,7 @@ smn:TargetOrLimitRateOrAbundance rdf:type owl:Class ;
 smn:TotalExploitationRate rdf:type owl:Class ;
                           rdfs:subClassOf gcdfo:ObservedExploitationRate ;
                           <http://purl.obolibrary.org/obo/IAO_0000115> "The overall proportion of the total return of adult salmon removed by all fisheries over a defined period, aggregating across gear or fishery components."@en ;
-                          rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                          rdfs:isDefinedBy <https://w3id.org/smn> ;
                           rdfs:label "Total exploitation rate"@en ;
                           gcdfo:theme gcdfo:FisheriesManagementTheme ,
                                       gcdfo:StockAssessmentTheme .
@@ -3495,7 +3495,7 @@ gcdfo:YearBasisScheme rdf:type owl:NamedIndividual ,
 
 ###  https://w3id.org/smn/CatchContext
 smn:CatchContext rdf:type skos:Concept ;
-                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                 rdfs:isDefinedBy <https://w3id.org/smn> ;
                  skos:broader smn:MeasurementContext ;
                  skos:definition "Measurement context indicating values refer to fishery catch."@en ;
                  skos:inScheme smn:MeasurementContextScheme ;
@@ -3506,7 +3506,7 @@ smn:CatchContext rdf:type skos:Concept ;
 ###  https://w3id.org/smn/EnumerationMethod
 smn:EnumerationMethod rdf:type owl:NamedIndividual ,
                                skos:Concept ;
-                      rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                      rdfs:isDefinedBy <https://w3id.org/smn> ;
                       skos:definition "A method used to enumerate or count salmon in the field"@en ;
                       skos:inScheme gcdfo:EnumerationMethodScheme ;
                       skos:prefLabel "Enumeration Method"@en ;
@@ -3519,7 +3519,7 @@ smn:EnumerationMethod rdf:type owl:NamedIndividual ,
 smn:HatcheryOrigin rdf:type skos:Concept ;
                    <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2018. Review of genetically based targets for enhanced contributions to Canadian Pacific Chinook Salmon populations. DFO Canadian Science Advisory Secretariat Science Advisory Report 2018/001 (Erratum: October 2023)."@en ;
                    dcterms:source <https://www.dfo-mpo.gc.ca/csas-sccs/Publications/SAR-AS/2018/2018_001-eng.html> ;
-                   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                   rdfs:isDefinedBy <https://w3id.org/smn> ;
                    skos:broader smn:SalmonOrigin ;
                    skos:definition "Individuals that were born or reared in a hatchery facility."@en ;
                    skos:inScheme smn:SalmonOriginScheme ;
@@ -3531,7 +3531,7 @@ smn:HatcheryOrigin rdf:type skos:Concept ;
 
 ###  https://w3id.org/smn/InRiverPhase
 smn:InRiverPhase rdf:type skos:Concept ;
-                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                 rdfs:isDefinedBy <https://w3id.org/smn> ;
                  skos:altLabel "Freshwater phase"@en ;
                  skos:broader smn:LifePhase ;
                  skos:definition "Freshwater in-river phase (migration and/or residence) outside the marine environment."@en ;
@@ -3542,7 +3542,7 @@ smn:InRiverPhase rdf:type skos:Concept ;
 
 ###  https://w3id.org/smn/LifePhase
 smn:LifePhase rdf:type skos:Concept ;
-              rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+              rdfs:isDefinedBy <https://w3id.org/smn> ;
               skos:definition "A phase or segment used to stratify salmon measurements by where or when they apply (e.g., ocean phase, terminal phase)."@en ;
               skos:inScheme smn:LifePhaseScheme ;
               skos:prefLabel "Life phase"@en ;
@@ -3551,7 +3551,7 @@ smn:LifePhase rdf:type skos:Concept ;
 
 ###  https://w3id.org/smn/LifePhaseScheme
 smn:LifePhaseScheme rdf:type skos:ConceptScheme ;
-                    rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                    rdfs:isDefinedBy <https://w3id.org/smn> ;
                     skos:definition "Controlled vocabulary for life-phase or fishery/migration segment qualifiers used to stratify measurements (e.g., ocean, terminal, mainstem)."@en ;
                     skos:hasTopConcept smn:LifePhase ;
                     skos:prefLabel "Life phase scheme"@en ;
@@ -3560,7 +3560,7 @@ smn:LifePhaseScheme rdf:type skos:ConceptScheme ;
 
 ###  https://w3id.org/smn/MainstemPhase
 smn:MainstemPhase rdf:type skos:Concept ;
-                  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                  rdfs:isDefinedBy <https://w3id.org/smn> ;
                   skos:broader smn:LifePhase ;
                   skos:definition "Freshwater mainstem migration phase in a river system (often corresponding to mainstem in-river fisheries or monitoring segments)."@en ;
                   skos:inScheme smn:LifePhaseScheme ;
@@ -3570,7 +3570,7 @@ smn:MainstemPhase rdf:type skos:Concept ;
 
 ###  https://w3id.org/smn/MeasurementContext
 smn:MeasurementContext rdf:type skos:Concept ;
-                       rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                       rdfs:isDefinedBy <https://w3id.org/smn> ;
                        skos:definition "A context qualifier used to disambiguate the interpretation of a measurement column."@en ;
                        skos:inScheme smn:MeasurementContextScheme ;
                        skos:prefLabel "Measurement context"@en ;
@@ -3580,7 +3580,7 @@ smn:MeasurementContext rdf:type skos:Concept ;
 
 ###  https://w3id.org/smn/MeasurementContextScheme
 smn:MeasurementContextScheme rdf:type skos:ConceptScheme ;
-                             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                             rdfs:isDefinedBy <https://w3id.org/smn> ;
                              skos:definition "Controlled vocabulary for compositional measurement context qualifiers (for example, catch context, run context)."@en ;
                              skos:hasTopConcept smn:MeasurementContext ;
                              skos:prefLabel "Measurement context scheme"@en ;
@@ -3592,7 +3592,7 @@ smn:MeasurementContextScheme rdf:type skos:ConceptScheme ;
 smn:NaturalOrigin rdf:type skos:Concept ;
                   <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2018. Review of genetically based targets for enhanced contributions to Canadian Pacific Chinook Salmon populations. DFO Canadian Science Advisory Secretariat Science Advisory Report 2018/001 (Erratum: October 2023)."@en ;
                   dcterms:source <https://www.dfo-mpo.gc.ca/csas-sccs/Publications/SAR-AS/2018/2018_001-eng.html> ;
-                  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                  rdfs:isDefinedBy <https://w3id.org/smn> ;
                   skos:broader smn:SalmonOrigin ;
                   skos:definition "Individuals that are born and reared in the wild (natural environment)."@en ;
                   skos:inScheme smn:SalmonOriginScheme ;
@@ -3604,7 +3604,7 @@ smn:NaturalOrigin rdf:type skos:Concept ;
 
 ###  https://w3id.org/smn/OceanPhase
 smn:OceanPhase rdf:type skos:Concept ;
-               rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+               rdfs:isDefinedBy <https://w3id.org/smn> ;
                skos:altLabel "Marine phase"@en ;
                skos:broader smn:LifePhase ;
                skos:definition "Phase of the salmon life cycle or assessment period occurring in the marine environment."@en ;
@@ -3615,7 +3615,7 @@ smn:OceanPhase rdf:type skos:Concept ;
 
 ###  https://w3id.org/smn/RunContext
 smn:RunContext rdf:type skos:Concept ;
-               rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+               rdfs:isDefinedBy <https://w3id.org/smn> ;
                skos:broader smn:MeasurementContext ;
                skos:definition "Measurement context indicating values refer to run size or returning run composition."@en ;
                skos:inScheme smn:MeasurementContextScheme ;
@@ -3625,7 +3625,7 @@ smn:RunContext rdf:type skos:Concept ;
 
 ###  https://w3id.org/smn/SalmonOrigin
 smn:SalmonOrigin rdf:type skos:Concept ;
-                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                 rdfs:isDefinedBy <https://w3id.org/smn> ;
                  skos:definition "Origin category describing whether salmon are naturally produced, hatchery produced, or mixed-origin."@en ;
                  skos:inScheme smn:SalmonOriginScheme ;
                  skos:prefLabel "Salmon origin"@en ;
@@ -3635,7 +3635,7 @@ smn:SalmonOrigin rdf:type skos:Concept ;
 
 ###  https://w3id.org/smn/SalmonOriginScheme
 smn:SalmonOriginScheme rdf:type skos:ConceptScheme ;
-                       rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                       rdfs:isDefinedBy <https://w3id.org/smn> ;
                        skos:definition "Controlled vocabulary for describing the origin of individual salmon (e.g., natural-origin, hatchery-origin, mixed-origin)."@en ;
                        skos:hasTopConcept smn:SalmonOrigin ;
                        skos:prefLabel "Salmon Origin Scheme"@en ;
@@ -3646,7 +3646,7 @@ smn:SalmonOriginScheme rdf:type skos:ConceptScheme ;
 
 ###  https://w3id.org/smn/SpawnerStageContext
 smn:SpawnerStageContext rdf:type skos:Concept ;
-                        rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                        rdfs:isDefinedBy <https://w3id.org/smn> ;
                         skos:broader smn:MeasurementContext ;
                         skos:definition "Measurement context indicating values refer to spawners or spawning-stage fish."@en ;
                         skos:inScheme smn:MeasurementContextScheme ;
@@ -3656,7 +3656,7 @@ smn:SpawnerStageContext rdf:type skos:Concept ;
 
 ###  https://w3id.org/smn/SurvivalOrMortalityContext
 smn:SurvivalOrMortalityContext rdf:type skos:Concept ;
-                               rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                               rdfs:isDefinedBy <https://w3id.org/smn> ;
                                skos:broader smn:MeasurementContext ;
                                skos:definition "Measurement context indicating values represent survival, mortality, or related rates."@en ;
                                skos:inScheme smn:MeasurementContextScheme ;
@@ -3666,7 +3666,7 @@ smn:SurvivalOrMortalityContext rdf:type skos:Concept ;
 
 ###  https://w3id.org/smn/TerminalPhase
 smn:TerminalPhase rdf:type skos:Concept ;
-                  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+                  rdfs:isDefinedBy <https://w3id.org/smn> ;
                   skos:broader smn:LifePhase ;
                   skos:definition "Phase occurring in terminal areas near river mouths or spawning areas (often including terminal fisheries and local migration to spawning sites)."@en ;
                   skos:inScheme smn:LifePhaseScheme ;

--- a/docs/gcdfo.ttl
+++ b/docs/gcdfo.ttl
@@ -193,6 +193,7 @@ gcdfo:iadoptProperty rdf:type owl:AnnotationProperty ;
 
 ###  https://w3id.org/gcdfo/salmon#theme
 gcdfo:theme rdf:type owl:AnnotationProperty ;
+            <http://purl.obolibrary.org/obo/IAO_0000115> "Associates OWL classes and SKOS concepts with high-level thematic concept schemes (e.g., Stock Assessment, GSI, Policy)."@en ;
             rdfs:comment "Associates OWL classes and SKOS concepts with high-level thematic concept schemes (e.g., Stock Assessment, GSI, Policy)."@en ;
             rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
             rdfs:label "theme"@en ;
@@ -2885,6 +2886,7 @@ gcdfo:RapidStatusConfidenceHigh rdf:type owl:NamedIndividual ,
                                 <http://purl.obolibrary.org/obo/IAO_0000115> "Rapid status confidence category indicating that high-quality abundance metrics support the result."@en ;
                                 rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
                                 rdfs:label "High rapid-status confidence"@en ;
+                                skos:definition "Rapid status confidence category indicating that high-quality abundance metrics support the result."@en ;
                                 skos:inScheme gcdfo:RapidStatusConfidenceScheme ;
                                 skos:prefLabel "High confidence"@en ;
                                 gcdfo:theme gcdfo:StockAssessmentTheme ,
@@ -2898,6 +2900,7 @@ gcdfo:RapidStatusConfidenceLow rdf:type owl:NamedIndividual ,
                                <http://purl.obolibrary.org/obo/IAO_0000115> "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone)."@en ;
                                rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
                                rdfs:label "Low rapid-status confidence"@en ;
+                               skos:definition "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone)."@en ;
                                skos:inScheme gcdfo:RapidStatusConfidenceScheme ;
                                skos:prefLabel "Low confidence"@en ;
                                gcdfo:theme gcdfo:StockAssessmentTheme ,
@@ -2911,6 +2914,7 @@ gcdfo:RapidStatusConfidenceMedium rdf:type owl:NamedIndividual ,
                                   <http://purl.obolibrary.org/obo/IAO_0000115> "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information."@en ;
                                   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
                                   rdfs:label "Medium rapid-status confidence"@en ;
+                                  skos:definition "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information."@en ;
                                   skos:inScheme gcdfo:RapidStatusConfidenceScheme ;
                                   skos:prefLabel "Medium confidence"@en ;
                                   gcdfo:theme gcdfo:StockAssessmentTheme ,

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -203,7 +203,7 @@ This section lists the formal classes, properties, and controlled vocabularies t
    </li>
    <li>
       <a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">
-         <span>Enumeration method</span>
+         <span>Enumeration Method</span>
       </a>
    </li>
    <li>
@@ -752,7 +752,7 @@ This section provides details for each class and property defined by DFO Salmon 
   <li><a href="#http://purl.obolibrary.org/obo/IAO_0000033" title="http://purl.obolibrary.org/obo/IAO_0000033">directive information entity</a></li>
   <li><a href="#http://purl.obolibrary.org/obo/IAO_0000310" title="http://purl.obolibrary.org/obo/IAO_0000310">document</a></li>
   <li><a href="#https://w3id.org/smn/Entity" title="https://w3id.org/smn/Entity">Entity</a></li>
-  <li><a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod"> <span>Enumeration method</span> </a></li>
+  <li><a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod"> <span>Enumeration Method</span> </a></li>
   <li><a href="#https://w3id.org/smn/Escapement" title="https://w3id.org/smn/Escapement">Escapement</a></li>
   <li><a href="#https://w3id.org/smn/EscapementMeasurement" title="https://w3id.org/smn/EscapementMeasurement">Escapement measurement</a></li>
   <li><a href="#https://w3id.org/smn/EscapementSurveyEvent" title="https://w3id.org/smn/EscapementSurveyEvent">Escapement Survey Event</a></li>
@@ -1279,7 +1279,7 @@ This section provides details for each class and property defined by DFO Salmon 
   </dl>
  </div>
  <div class="entity" id="https://w3id.org/smn/EnumerationMethod">
-  <h3>Enumeration method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
+  <h3>Enumeration Method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/EnumerationMethod</p>
   <dl class="description">
    <dt>
@@ -3099,7 +3099,7 @@ This section provides details for each class and property defined by DFO Salmon 
     has sub-classes
    </dt>
    <dd>
-    <a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-c" title="class">c</sup>, <a href="#https://w3id.org/smn/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-c" title="class">c</sup>
+    <a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration Method</a> <sup class="type-c" title="class">c</sup>, <a href="#https://w3id.org/smn/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-c" title="class">c</sup>
    </dd>
   </dl>
  </div>
@@ -4891,7 +4891,7 @@ This section provides details for each class and property defined by DFO Salmon 
      has range
     </dt>
     <dd>
-     <a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-c" title="class">c</sup>
+     <a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration Method</a> <sup class="type-c" title="class">c</sup>
     </dd>
    </dl>
   </div>
@@ -5900,6 +5900,11 @@ This section provides details for each class and property defined by DFO Salmon 
 <li>Added: EquivalentClasses EquivalentClasses(&lt;http://rs.tdwg.org/dwc/terms/Occurrence&gt; &lt;http://www.w3.org/ns/sosa/Observation&gt;)</li>
 </ul>
 </li>
+<li><a href="#ConfidenceCategory">https://w3id.org/gcdfo/salmon#ConfidenceCategory</a>
+<ul>
+<li>Added: rdfs:label "Confidence category"@en</li>
+</ul>
+</li>
 <li><a href="#ConservationUnit">https://w3id.org/gcdfo/salmon#ConservationUnit</a>
 <ul>
 <li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2005. Canada's Policy for Conservation of Wild Pacific Salmon. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/315577.pdf."@en</li>
@@ -5940,6 +5945,7 @@ This section provides details for each class and property defined by DFO Salmon 
 <li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Wild Salmon Policy 2018-2022 Implementation Plan. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf."@en</li>
 <li>Added: <http://purl.org/dc/terms/source> https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf</li>
 <li>Added: <http://www.w3.org/2004/02/skos/core#inScheme> https://w3id.org/gcdfo/salmon#WSPBiologicalStatusZoneScheme</li>
+<li>Added: rdfs:label "Wild Salmon Policy biological status zone"@en</li>
 </ul>
 <ul>
 <li>Deleted: <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. (2021). Wild Salmon Policy 2018-2022 Implementation Plan. Available at https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf."@en</li>

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -876,6 +876,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/AggregatedMeasurement">
   <h3>Aggregated measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/AggregatedMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -894,6 +902,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/alevin">
   <h3>Alevin<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/alevin</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -966,6 +982,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/BodyShape">
   <h3>Body shape<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/BodyShape</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -984,6 +1008,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/Characteristic">
   <h3>Characteristic<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Characteristic</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1091,6 +1123,14 @@ This section provides details for each class and property defined by DFO Salmon 
   <div class="comment">
    <span class="markdown">An assessment artifact describing confidence, uncertainty, and quality constraints for a salmon data product or metric.</span>
   </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1110,6 +1150,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -1215,6 +1258,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/Entity">
   <h3>Entity<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Entity</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1265,6 +1316,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -1298,6 +1352,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -1333,6 +1390,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -1395,6 +1455,14 @@ This section provides details for each class and property defined by DFO Salmon 
   <div class="comment">
    <span class="markdown">A class used to categorize fisheries or survey event instances by operational type.</span>
   </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has sub-classes
@@ -1420,6 +1488,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -1507,6 +1578,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/FishForkLengthMeasurementMethod">
   <h3>Fish fork-length measurement method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishForkLengthMeasurementMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1525,6 +1604,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/FishLength">
   <h3>Fish length<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishLength</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     is equivalent to
@@ -1549,6 +1636,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/FishLengthMeasurementMethod">
   <h3>Fish length measurement method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishLengthMeasurementMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1567,6 +1662,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/FishLengthMeasurementType">
   <h3>Fish length measurement type<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishLengthMeasurementType</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1631,6 +1734,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/FishWeight">
   <h3>Fish weight<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishWeight</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1697,6 +1808,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/FishingType">
   <h3>Fishing type<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishingType</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1715,11 +1834,27 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/forkLength">
   <h3>Fork length<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/forkLength</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description"></dl>
  </div>
  <div class="entity" id="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">
   <h3>Fork-length field method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementFieldMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1732,6 +1867,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/ForkLengthMeasurementLabMethod">
   <h3>Fork-length lab method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementLabMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1744,6 +1887,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/ForkLengthMeasurement">
   <h3>Fork-length measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1756,6 +1907,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/ForkLengthMeasurementMethod">
   <h3>Fork-length measurement method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1774,6 +1933,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/fusiform">
   <h3>Fusiform<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/fusiform</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1809,6 +1976,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/GeographicFeature">
   <h3>Geographic feature<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/GeographicFeature</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1827,6 +2002,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/HabitatUnit">
   <h3>Habitat unit<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/HabitatUnit</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -1915,6 +2098,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -1938,6 +2124,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/IndividualMeasurement">
   <h3>Individual measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/IndividualMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -2031,6 +2225,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/Life-HistoryCharacteristic">
   <h3>Life-history characteristic<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Life-HistoryCharacteristic</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -2056,6 +2258,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -2295,6 +2500,17 @@ This section provides details for each class and property defined by DFO Salmon 
   <div class="comment">
    <span class="markdown">A salmon-domain observation focused on one feature of interest and one characteristic.</span>
   </div>
+  <div class="comment">
+   <span class="markdown">A salmon-domain observation focused on one feature of interest and one characteristic.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -2363,6 +2579,14 @@ This section provides details for each class and property defined by DFO Salmon 
   <div class="comment">
    <span class="markdown">A documented method description linked to how a salmon metric or estimate was produced.</span>
   </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -2385,6 +2609,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -2418,6 +2645,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/ModelMeasurement">
   <h3>Model measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/ModelMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -2430,6 +2665,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/MorphologicalCharacteristic">
   <h3>Morphological characteristic<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/MorphologicalCharacteristic</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -2490,6 +2733,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/Observation">
   <h3>Observation<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Observation</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -2567,6 +2818,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -2666,6 +2920,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/NCBITaxon_8018">
   <h3>Oncorhynchus keta proxy class<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/NCBITaxon_8018</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -2678,6 +2940,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/orbitalLength">
   <h3>Orbital length<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/orbitalLength</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -2823,6 +3093,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -3019,6 +3292,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -3510,6 +3786,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -3566,6 +3845,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/Run">
   <h3>Run<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Run</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -3601,6 +3888,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/SalmonGroup">
   <h3>Salmon group<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/SalmonGroup</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -3619,6 +3914,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/SalmonIndividual">
   <h3>Salmon individual<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/SalmonIndividual</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -3631,6 +3934,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/SalmonLifeStage">
   <h3>Salmon life stage<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/SalmonLifeStage</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -3649,6 +3960,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/SalmonPopulationGroup">
   <h3>Salmon population group<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/SalmonPopulationGroup</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -3661,6 +3980,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/SalmonStockUnit">
   <h3>Salmon stock unit<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/SalmonStockUnit</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -3696,6 +4023,17 @@ This section provides details for each class and property defined by DFO Salmon 
   <div class="comment">
    <span class="markdown">A sampling activity that targets a geographic feature, yields a sample, and records a time.</span>
   </div>
+  <div class="comment">
+   <span class="markdown">A sampling activity that targets a geographic feature, yields a sample, and records a time.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -3714,6 +4052,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/seiningEvent">
   <h3>Seining event<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/seiningEvent</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -3910,6 +4256,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/standardLength">
   <h3>Standard length<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/standardLength</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -3922,6 +4276,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/StandardLengthMeasurement">
   <h3>Standard length measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/StandardLengthMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -3941,6 +4303,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -3975,6 +4340,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -4100,6 +4468,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -4192,6 +4563,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -4264,6 +4638,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -4285,6 +4662,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/totalLength">
   <h3>Total length<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/totalLength</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -4297,6 +4682,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/TotalLengthMeasurement">
   <h3>Total length measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/TotalLengthMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -4529,6 +4922,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/basedOn">
   <h3>based on<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/basedOn</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <div class="description">
    <dl>
     <dt>
@@ -4549,6 +4950,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/characteristicFor">
   <h3>characteristic for<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/characteristicFor</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <div class="description">
    <dl>
     <dt>
@@ -4613,6 +5022,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -4768,6 +5180,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -4803,6 +5218,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/hasEventType">
   <h3>has event type<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/hasEventType</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <div class="description">
    <dl>
     <dt>
@@ -4860,6 +5283,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/hasMeasurement">
   <h3>has measurement<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/hasMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <div class="description">
    <dl>
     <dt>
@@ -4964,6 +5395,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -5285,6 +5719,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/observedTaxonFamily">
   <h3>observed taxon family<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/observedTaxonFamily</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <div class="description">
    <dl>
     <dt>
@@ -5305,6 +5747,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/observedTaxonSpecies">
   <h3>observed taxon species<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/observedTaxonSpecies</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <div class="description">
    <dl>
     <dt>
@@ -5335,6 +5785,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -1153,9 +1153,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="description">
    <dt>
@@ -1318,9 +1315,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="definedBy">
    <dt>
@@ -1354,9 +1348,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="description">
@@ -1392,9 +1383,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="description">
@@ -1490,9 +1478,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="definedBy">
@@ -1762,7 +1747,7 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
   </dl>
   <dl class="definedBy">
@@ -2100,9 +2085,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="definedBy">
    <dt>
@@ -2260,9 +2242,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="definedBy">
@@ -2612,9 +2591,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="definedBy">
    <dt>
@@ -2820,9 +2796,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="description">
@@ -3096,9 +3069,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="description">
    <dt>
@@ -3294,9 +3264,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="definedBy">
@@ -3787,9 +3754,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="description">
@@ -4306,9 +4270,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="definedBy">
    <dt>
@@ -4342,9 +4303,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="definedBy">
@@ -4470,9 +4428,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="definedBy">
    <dt>
@@ -4565,9 +4520,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="description">
    <dt>
@@ -4639,9 +4591,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="description">
@@ -5025,9 +4974,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <div class="description">
    <dl>
@@ -5181,9 +5127,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <div class="description">
@@ -5397,9 +5340,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <div class="description">
@@ -5787,9 +5727,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <div class="description">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1854,15 +1854,15 @@ This section lists the formal classes, properties, and controlled vocabularies t
       </tr>
       <tr>
         <td><a href="#RapidStatusConfidenceHigh">High rapid-status confidence</a></td>
-        <td><em>No definition provided.</em></td>
+        <td>Rapid status confidence category indicating that high-quality abundance metrics support the result.</td>
       </tr>
       <tr>
         <td><a href="#RapidStatusConfidenceLow">Low rapid-status confidence</a></td>
-        <td><em>No definition provided.</em></td>
+        <td>Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone).</td>
       </tr>
       <tr>
         <td><a href="#RapidStatusConfidenceMedium">Medium rapid-status confidence</a></td>
-        <td><em>No definition provided.</em></td>
+        <td>Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information.</td>
       </tr>
     </tbody>
   </table>
@@ -3198,6 +3198,9 @@ This section lists the formal classes, properties, and controlled vocabularies t
 <div class="entity" id="RapidStatusConfidenceHigh">
   <h3>High rapid-status confidence<sup class="type-skos" title="SKOS concept">skos</sup></h3>
   <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#RapidStatusConfidenceHigh</p>
+  <div class="comment">
+    <span class="markdown">Rapid status confidence category indicating that high-quality abundance metrics support the result.</span>
+  </div>
   <dl class="definedBy">
     <dt>Is defined by</dt>
     <dd><a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a></dd>
@@ -3412,6 +3415,9 @@ This section lists the formal classes, properties, and controlled vocabularies t
 <div class="entity" id="RapidStatusConfidenceLow">
   <h3>Low rapid-status confidence<sup class="type-skos" title="SKOS concept">skos</sup></h3>
   <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#RapidStatusConfidenceLow</p>
+  <div class="comment">
+    <span class="markdown">Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone).</span>
+  </div>
   <dl class="definedBy">
     <dt>Is defined by</dt>
     <dd><a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a></dd>
@@ -3540,6 +3546,9 @@ This section lists the formal classes, properties, and controlled vocabularies t
 <div class="entity" id="RapidStatusConfidenceMedium">
   <h3>Medium rapid-status confidence<sup class="type-skos" title="SKOS concept">skos</sup></h3>
   <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#RapidStatusConfidenceMedium</p>
+  <div class="comment">
+    <span class="markdown">Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information.</span>
+  </div>
   <dl class="definedBy">
     <dt>Is defined by</dt>
     <dd><a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a></dd>
@@ -4733,6 +4742,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/AggregatedMeasurement">
   <h3>Aggregated measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/AggregatedMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -4751,6 +4768,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/alevin">
   <h3>Alevin<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/alevin</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -4823,6 +4848,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/BodyShape">
   <h3>Body shape<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/BodyShape</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -4841,6 +4874,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/Characteristic">
   <h3>Characteristic<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Characteristic</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -4948,6 +4989,14 @@ This section provides details for each class and property defined by DFO Salmon 
   <div class="comment">
    <span class="markdown">An assessment artifact describing confidence, uncertainty, and quality constraints for a salmon data product or metric.</span>
   </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -4967,6 +5016,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -5072,6 +5124,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/Entity">
   <h3>Entity<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Entity</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5122,6 +5182,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -5155,6 +5218,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -5190,6 +5256,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -5252,6 +5321,14 @@ This section provides details for each class and property defined by DFO Salmon 
   <div class="comment">
    <span class="markdown">A class used to categorize fisheries or survey event instances by operational type.</span>
   </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has sub-classes
@@ -5277,6 +5354,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -5364,6 +5444,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/FishForkLengthMeasurementMethod">
   <h3>Fish fork-length measurement method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishForkLengthMeasurementMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5382,6 +5470,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/FishLength">
   <h3>Fish length<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishLength</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     is equivalent to
@@ -5406,6 +5502,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/FishLengthMeasurementMethod">
   <h3>Fish length measurement method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishLengthMeasurementMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5424,6 +5528,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/FishLengthMeasurementType">
   <h3>Fish length measurement type<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishLengthMeasurementType</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5488,6 +5600,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/FishWeight">
   <h3>Fish weight<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishWeight</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5554,6 +5674,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/FishingType">
   <h3>Fishing type<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishingType</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5572,11 +5700,27 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/forkLength">
   <h3>Fork length<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/forkLength</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description"></dl>
  </div>
  <div class="entity" id="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">
   <h3>Fork-length field method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementFieldMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5589,6 +5733,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/ForkLengthMeasurementLabMethod">
   <h3>Fork-length lab method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementLabMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5601,6 +5753,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/ForkLengthMeasurement">
   <h3>Fork-length measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5613,6 +5773,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/ForkLengthMeasurementMethod">
   <h3>Fork-length measurement method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5631,6 +5799,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/fusiform">
   <h3>Fusiform<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/fusiform</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5666,6 +5842,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/GeographicFeature">
   <h3>Geographic feature<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/GeographicFeature</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5684,6 +5868,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/HabitatUnit">
   <h3>Habitat unit<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/HabitatUnit</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5772,6 +5964,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -5795,6 +5990,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/IndividualMeasurement">
   <h3>Individual measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/IndividualMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5888,6 +6091,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/Life-HistoryCharacteristic">
   <h3>Life-history characteristic<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Life-HistoryCharacteristic</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -5913,6 +6124,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -6152,6 +6366,17 @@ This section provides details for each class and property defined by DFO Salmon 
   <div class="comment">
    <span class="markdown">A salmon-domain observation focused on one feature of interest and one characteristic.</span>
   </div>
+  <div class="comment">
+   <span class="markdown">A salmon-domain observation focused on one feature of interest and one characteristic.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -6220,6 +6445,14 @@ This section provides details for each class and property defined by DFO Salmon 
   <div class="comment">
    <span class="markdown">A documented method description linked to how a salmon metric or estimate was produced.</span>
   </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -6242,6 +6475,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -6275,6 +6511,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/ModelMeasurement">
   <h3>Model measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/ModelMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -6287,6 +6531,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/MorphologicalCharacteristic">
   <h3>Morphological characteristic<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/MorphologicalCharacteristic</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -6347,6 +6599,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/Observation">
   <h3>Observation<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Observation</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -6424,6 +6684,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -6523,6 +6786,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/NCBITaxon_8018">
   <h3>Oncorhynchus keta proxy class<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/NCBITaxon_8018</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -6535,6 +6806,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/orbitalLength">
   <h3>Orbital length<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/orbitalLength</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -6680,6 +6959,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -6876,6 +7158,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -7367,6 +7652,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -7423,6 +7711,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/Run">
   <h3>Run<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Run</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -7458,6 +7754,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/SalmonGroup">
   <h3>Salmon group<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/SalmonGroup</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -7476,6 +7780,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/SalmonIndividual">
   <h3>Salmon individual<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/SalmonIndividual</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -7488,6 +7800,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/SalmonLifeStage">
   <h3>Salmon life stage<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/SalmonLifeStage</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -7506,6 +7826,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/SalmonPopulationGroup">
   <h3>Salmon population group<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/SalmonPopulationGroup</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -7518,6 +7846,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/SalmonStockUnit">
   <h3>Salmon stock unit<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/SalmonStockUnit</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -7553,6 +7889,17 @@ This section provides details for each class and property defined by DFO Salmon 
   <div class="comment">
    <span class="markdown">A sampling activity that targets a geographic feature, yields a sample, and records a time.</span>
   </div>
+  <div class="comment">
+   <span class="markdown">A sampling activity that targets a geographic feature, yields a sample, and records a time.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -7571,6 +7918,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/seiningEvent">
   <h3>Seining event<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/seiningEvent</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -7767,6 +8122,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/standardLength">
   <h3>Standard length<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/standardLength</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -7779,6 +8142,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/StandardLengthMeasurement">
   <h3>Standard length measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/StandardLengthMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -7798,6 +8169,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -7832,6 +8206,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -7957,6 +8334,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -8049,6 +8429,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -8121,6 +8504,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -8142,6 +8528,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/totalLength">
   <h3>Total length<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/totalLength</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -8154,6 +8548,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/TotalLengthMeasurement">
   <h3>Total length measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/TotalLengthMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <dl class="description">
    <dt>
     has super-classes
@@ -8386,6 +8788,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/basedOn">
   <h3>based on<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/basedOn</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <div class="description">
    <dl>
     <dt>
@@ -8406,6 +8816,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/characteristicFor">
   <h3>characteristic for<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/characteristicFor</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <div class="description">
    <dl>
     <dt>
@@ -8470,6 +8888,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -8625,6 +9046,9 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+   <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
@@ -8660,6 +9084,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/hasEventType">
   <h3>has event type<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/hasEventType</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <div class="description">
    <dl>
     <dt>
@@ -8717,6 +9149,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/hasMeasurement">
   <h3>has measurement<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/hasMeasurement</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <div class="description">
    <dl>
     <dt>
@@ -8821,6 +9261,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
@@ -9142,6 +9585,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/observedTaxonFamily">
   <h3>observed taxon family<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/observedTaxonFamily</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <div class="description">
    <dl>
     <dt>
@@ -9162,6 +9613,14 @@ This section provides details for each class and property defined by DFO Salmon 
  <div class="entity" id="https://w3id.org/smn/observedTaxonSpecies">
   <h3>observed taxon species<sup class="type-op" title="object property">op</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/observedTaxonSpecies</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
   <div class="description">
    <dl>
     <dt>
@@ -9192,6 +9651,9 @@ This section provides details for each class and property defined by DFO Salmon 
    <dt>
     Is defined by
    </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
    <dd>
     <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>

--- a/docs/index.html
+++ b/docs/index.html
@@ -694,7 +694,7 @@ This section lists the formal classes, properties, and controlled vocabularies t
    </li>
    <li>
       <a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">
-         <span>Enumeration method</span>
+         <span>Enumeration Method</span>
       </a>
    </li>
    <li>
@@ -1853,15 +1853,15 @@ This section lists the formal classes, properties, and controlled vocabularies t
         <td>Categorical confidence rating (High, Medium, Low) for stock assessment metrics.</td>
       </tr>
       <tr>
-        <td><a href="#RapidStatusConfidenceHigh">High rapid-status confidence</a></td>
+        <td><a href="#RapidStatusConfidenceHigh">High confidence</a></td>
         <td>Rapid status confidence category indicating that high-quality abundance metrics support the result.</td>
       </tr>
       <tr>
-        <td><a href="#RapidStatusConfidenceLow">Low rapid-status confidence</a></td>
+        <td><a href="#RapidStatusConfidenceLow">Low confidence</a></td>
         <td>Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone).</td>
       </tr>
       <tr>
-        <td><a href="#RapidStatusConfidenceMedium">Medium rapid-status confidence</a></td>
+        <td><a href="#RapidStatusConfidenceMedium">Medium confidence</a></td>
         <td>Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information.</td>
       </tr>
     </tbody>
@@ -3196,7 +3196,7 @@ This section lists the formal classes, properties, and controlled vocabularies t
   </dl>
 </div>
 <div class="entity" id="RapidStatusConfidenceHigh">
-  <h3>High rapid-status confidence<sup class="type-skos" title="SKOS concept">skos</sup></h3>
+  <h3>High confidence<sup class="type-skos" title="SKOS concept">skos</sup></h3>
   <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#RapidStatusConfidenceHigh</p>
   <div class="comment">
     <span class="markdown">Rapid status confidence category indicating that high-quality abundance metrics support the result.</span>
@@ -3413,7 +3413,7 @@ This section lists the formal classes, properties, and controlled vocabularies t
   </dl>
 </div>
 <div class="entity" id="RapidStatusConfidenceLow">
-  <h3>Low rapid-status confidence<sup class="type-skos" title="SKOS concept">skos</sup></h3>
+  <h3>Low confidence<sup class="type-skos" title="SKOS concept">skos</sup></h3>
   <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#RapidStatusConfidenceLow</p>
   <div class="comment">
     <span class="markdown">Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone).</span>
@@ -3544,7 +3544,7 @@ This section lists the formal classes, properties, and controlled vocabularies t
   </dl>
 </div>
 <div class="entity" id="RapidStatusConfidenceMedium">
-  <h3>Medium rapid-status confidence<sup class="type-skos" title="SKOS concept">skos</sup></h3>
+  <h3>Medium confidence<sup class="type-skos" title="SKOS concept">skos</sup></h3>
   <p><strong>IRI:</strong> https://w3id.org/gcdfo/salmon#RapidStatusConfidenceMedium</p>
   <div class="comment">
     <span class="markdown">Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information.</span>
@@ -4618,7 +4618,7 @@ This section provides details for each class and property defined by DFO Salmon 
   <li><a href="#http://purl.obolibrary.org/obo/IAO_0000033" title="http://purl.obolibrary.org/obo/IAO_0000033">directive information entity</a></li>
   <li><a href="#http://purl.obolibrary.org/obo/IAO_0000310" title="http://purl.obolibrary.org/obo/IAO_0000310">document</a></li>
   <li><a href="#https://w3id.org/smn/Entity" title="https://w3id.org/smn/Entity">Entity</a></li>
-  <li><a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod"> <span>Enumeration method</span> </a></li>
+  <li><a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod"> <span>Enumeration Method</span> </a></li>
   <li><a href="#https://w3id.org/smn/Escapement" title="https://w3id.org/smn/Escapement">Escapement</a></li>
   <li><a href="#https://w3id.org/smn/EscapementMeasurement" title="https://w3id.org/smn/EscapementMeasurement">Escapement measurement</a></li>
   <li><a href="#https://w3id.org/smn/EscapementSurveyEvent" title="https://w3id.org/smn/EscapementSurveyEvent">Escapement Survey Event</a></li>
@@ -5145,7 +5145,7 @@ This section provides details for each class and property defined by DFO Salmon 
   </dl>
  </div>
  <div class="entity" id="https://w3id.org/smn/EnumerationMethod">
-  <h3>Enumeration method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
+  <h3>Enumeration Method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/EnumerationMethod</p>
   <dl class="description">
    <dt>
@@ -6965,7 +6965,7 @@ This section provides details for each class and property defined by DFO Salmon 
     has sub-classes
    </dt>
    <dd>
-    <a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-c" title="class">c</sup>, <a href="#https://w3id.org/smn/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-c" title="class">c</sup>
+    <a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration Method</a> <sup class="type-c" title="class">c</sup>, <a href="#https://w3id.org/smn/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-c" title="class">c</sup>
    </dd>
   </dl>
  </div>
@@ -8757,7 +8757,7 @@ This section provides details for each class and property defined by DFO Salmon 
      has range
     </dt>
     <dd>
-     <a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-c" title="class">c</sup>
+     <a href="#https://w3id.org/smn/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration Method</a> <sup class="type-c" title="class">c</sup>
     </dd>
    </dl>
   </div>
@@ -9766,6 +9766,11 @@ This section provides details for each class and property defined by DFO Salmon 
 <li>Added: EquivalentClasses EquivalentClasses(&lt;http://rs.tdwg.org/dwc/terms/Occurrence&gt; &lt;http://www.w3.org/ns/sosa/Observation&gt;)</li>
 </ul>
 </li>
+<li><a href="#ConfidenceCategory">https://w3id.org/gcdfo/salmon#ConfidenceCategory</a>
+<ul>
+<li>Added: rdfs:label "Confidence category"@en</li>
+</ul>
+</li>
 <li><a href="#ConservationUnit">https://w3id.org/gcdfo/salmon#ConservationUnit</a>
 <ul>
 <li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. 2005. Canada's Policy for Conservation of Wild Pacific Salmon. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/315577.pdf."@en</li>
@@ -9806,6 +9811,7 @@ This section provides details for each class and property defined by DFO Salmon 
 <li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. Wild Salmon Policy 2018-2022 Implementation Plan. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf."@en</li>
 <li>Added: <http://purl.org/dc/terms/source> https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf</li>
 <li>Added: <http://www.w3.org/2004/02/skos/core#inScheme> https://w3id.org/gcdfo/salmon#WSPBiologicalStatusZoneScheme</li>
+<li>Added: rdfs:label "Wild Salmon Policy biological status zone"@en</li>
 </ul>
 <ul>
 <li>Deleted: <http://purl.obolibrary.org/obo/IAO_0000119> "Fisheries and Oceans Canada. (2021). Wild Salmon Policy 2018-2022 Implementation Plan. Available at https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf."@en</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5019,9 +5019,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="description">
    <dt>
@@ -5184,9 +5181,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="definedBy">
    <dt>
@@ -5220,9 +5214,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="description">
@@ -5258,9 +5249,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="description">
@@ -5356,9 +5344,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="definedBy">
@@ -5628,7 +5613,7 @@ This section provides details for each class and property defined by DFO Salmon 
     Is defined by
    </dt>
    <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
   </dl>
   <dl class="definedBy">
@@ -5966,9 +5951,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="definedBy">
    <dt>
@@ -6126,9 +6108,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="definedBy">
@@ -6478,9 +6457,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="definedBy">
    <dt>
@@ -6686,9 +6662,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="description">
@@ -6962,9 +6935,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="description">
    <dt>
@@ -7160,9 +7130,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="definedBy">
@@ -7653,9 +7620,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="description">
@@ -8172,9 +8136,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="definedBy">
    <dt>
@@ -8208,9 +8169,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="definedBy">
@@ -8336,9 +8294,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="definedBy">
    <dt>
@@ -8431,9 +8386,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <dl class="description">
    <dt>
@@ -8505,9 +8457,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <dl class="description">
@@ -8891,9 +8840,6 @@ This section provides details for each class and property defined by DFO Salmon 
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
    </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
-   </dd>
   </dl>
   <div class="description">
    <dl>
@@ -9047,9 +8993,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <div class="description">
@@ -9263,9 +9206,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <div class="description">
@@ -9653,9 +9593,6 @@ This section provides details for each class and property defined by DFO Salmon 
    </dt>
    <dd>
     <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-   <dd>
-    <a href="https://w3id.org/gcdfo/salmon">https://w3id.org/gcdfo/salmon</a>
    </dd>
   </dl>
   <div class="description">

--- a/docs/webvowl/data/ontology.json
+++ b/docs/webvowl/data/ontology.json
@@ -290,7 +290,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -337,7 +340,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -408,6 +414,7 @@
       "iri" : "https://w3id.org/smn/SalmonLifeStage",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "SalmonLifeStage", "en" : "Salmon life stage" },
       "subClasses" : [ "10" ],
       "attributes" : [ "external" ],
@@ -418,6 +425,7 @@
       "iri" : "https://w3id.org/smn/Characteristic",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "Characteristic", "en" : "Characteristic" },
       "subClasses" : [ "63", "8", "125", "115" ],
       "attributes" : [ "external" ],
@@ -428,6 +436,7 @@
       "iri" : "https://w3id.org/smn/alevin",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "alevin", "en" : "Alevin" },
       "attributes" : [ "external" ],
       "id" : "10",
@@ -477,7 +486,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -536,7 +548,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -840,7 +855,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "closeMatch" : [ { "identifier" : "closeMatch", "language" : "undefined", "value" : "http://www.w3.org/ns/sosa/FeatureOfInterest", "type" : "iri" } ],
         "IAO_0000115" : [
           {
@@ -872,7 +890,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -909,7 +930,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -998,6 +1022,7 @@
       "iri" : "https://w3id.org/smn/Observation",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "Observation", "en" : "Observation" },
       "subClasses" : [ "81" ],
       "attributes" : [ "external" ],
@@ -1043,7 +1068,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -1158,7 +1186,8 @@
             "value" : "A documented method description linked to how a salmon metric or estimate was produced.",
             "type" : "label"
           }
-        ]
+        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ]
       },
       "label" : { "IRI-based" : "MethodDocumentation", "en" : "Method documentation" },
       "attributes" : [ "external" ],
@@ -1230,6 +1259,7 @@
       "iri" : "https://w3id.org/smn/NCBITaxon_8018",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "NCBITaxon_8018", "en" : "Oncorhynchus keta proxy class" },
       "attributes" : [ "external" ],
       "id" : "55",
@@ -1281,6 +1311,7 @@
       "iri" : "https://w3id.org/smn/fusiform",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "fusiform", "en" : "Fusiform" },
       "attributes" : [ "external" ],
       "id" : "62",
@@ -1290,6 +1321,7 @@
       "iri" : "https://w3id.org/smn/BodyShape",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "BodyShape", "en" : "Body shape" },
       "subClasses" : [ "62" ],
       "attributes" : [ "external" ],
@@ -1300,6 +1332,7 @@
       "iri" : "https://w3id.org/smn/ForkLengthMeasurement",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "ForkLengthMeasurement", "en" : "Fork-length measurement" },
       "attributes" : [ "external" ],
       "id" : "64",
@@ -1309,6 +1342,7 @@
       "iri" : "https://w3id.org/smn/FishLengthMeasurementType",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "FishLengthMeasurementType", "en" : "Fish length measurement type" },
       "subClasses" : [ "161", "64", "147" ],
       "attributes" : [ "external" ],
@@ -1378,7 +1412,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -1410,7 +1447,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -1662,7 +1702,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "closeMatch" : [ { "identifier" : "closeMatch", "language" : "undefined", "value" : "http://www.w3.org/ns/sosa/FeatureOfInterest", "type" : "iri" } ],
         "IAO_0000115" : [
           {
@@ -1695,6 +1738,17 @@
       "iri" : "https://w3id.org/smn/Measurement",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : {
+        "IAO_0000115" : [
+          {
+            "identifier" : "IAO_0000115",
+            "language" : "en",
+            "value" : "A salmon-domain observation focused on one feature of interest and one characteristic.",
+            "type" : "label"
+          }
+        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ]
+      },
       "label" : { "IRI-based" : "Measurement", "en" : "Measurement" },
       "subClasses" : [ "65", "82", "83", "84" ],
       "comment" : { "en" : "A salmon-domain observation focused on one feature of interest and one characteristic." },
@@ -1706,6 +1760,7 @@
       "iri" : "https://w3id.org/smn/IndividualMeasurement",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "IndividualMeasurement", "en" : "Individual measurement" },
       "attributes" : [ "external" ],
       "id" : "82",
@@ -1715,6 +1770,7 @@
       "iri" : "https://w3id.org/smn/AggregatedMeasurement",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "AggregatedMeasurement", "en" : "Aggregated measurement" },
       "attributes" : [ "external" ],
       "id" : "83",
@@ -1724,6 +1780,7 @@
       "iri" : "https://w3id.org/smn/ModelMeasurement",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "ModelMeasurement", "en" : "Model measurement" },
       "attributes" : [ "external" ],
       "id" : "84",
@@ -1734,7 +1791,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -1804,7 +1864,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           { "identifier" : "IAO_0000115", "language" : "en", "value" : "A survey event specifically for estimating escapement.", "type" : "label" }
         ],
@@ -1844,6 +1907,7 @@
       "iri" : "https://w3id.org/smn/Entity",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "Entity", "en" : "Entity" },
       "subClasses" : [ "95", "96", "97" ],
       "attributes" : [ "external" ],
@@ -1864,6 +1928,7 @@
       "iri" : "https://w3id.org/smn/SalmonGroup",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "SalmonGroup", "en" : "Salmon group" },
       "subClasses" : [ "170", "210" ],
       "attributes" : [ "external" ],
@@ -1874,6 +1939,7 @@
       "iri" : "https://w3id.org/smn/HabitatUnit",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "HabitatUnit", "en" : "Habitat unit" },
       "attributes" : [ "external" ],
       "id" : "96",
@@ -1883,6 +1949,7 @@
       "iri" : "https://w3id.org/smn/SalmonIndividual",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "SalmonIndividual", "en" : "Salmon individual" },
       "attributes" : [ "external" ],
       "id" : "97",
@@ -1893,7 +1960,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -2109,6 +2179,7 @@
       "iri" : "https://w3id.org/smn/GeographicFeature",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "GeographicFeature", "en" : "Geographic feature" },
       "subClasses" : [ "80" ],
       "attributes" : [ "external" ],
@@ -2120,7 +2191,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -2172,7 +2246,8 @@
             "value" : "An assessment artifact describing confidence, uncertainty, and quality constraints for a salmon data product or metric.",
             "type" : "label"
           }
-        ]
+        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ]
       },
       "label" : { "IRI-based" : "DataQualityAssessment", "en" : "Data quality assessment" },
       "attributes" : [ "external" ],
@@ -2284,6 +2359,7 @@
       "iri" : "https://w3id.org/smn/Run",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "Run", "en" : "Run" },
       "attributes" : [ "external" ],
       "id" : "114",
@@ -2293,6 +2369,7 @@
       "iri" : "https://w3id.org/smn/Life-HistoryCharacteristic",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "Life-HistoryCharacteristic", "en" : "Life-history characteristic" },
       "subClasses" : [ "114" ],
       "attributes" : [ "external" ],
@@ -2340,6 +2417,17 @@
       "iri" : "https://w3id.org/smn/SamplingEvent",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : {
+        "IAO_0000115" : [
+          {
+            "identifier" : "IAO_0000115",
+            "language" : "en",
+            "value" : "A sampling activity that targets a geographic feature, yields a sample, and records a time.",
+            "type" : "label"
+          }
+        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ]
+      },
       "label" : { "IRI-based" : "SamplingEvent", "en" : "Sampling event" },
       "comment" : { "en" : "A sampling activity that targets a geographic feature, yields a sample, and records a time." },
       "attributes" : [ "external" ],
@@ -2370,6 +2458,7 @@
       "iri" : "https://w3id.org/smn/MorphologicalCharacteristic",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "MorphologicalCharacteristic", "en" : "Morphological characteristic" },
       "subClasses" : [ "224", "134" ],
       "attributes" : [ "external" ],
@@ -2472,7 +2561,8 @@
             "value" : "A class used to categorize fisheries or survey event instances by operational type.",
             "type" : "label"
           }
-        ]
+        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ]
       },
       "label" : { "IRI-based" : "EventType", "en" : "Event type" },
       "subClasses" : [ "129" ],
@@ -2483,6 +2573,7 @@
       "iri" : "https://w3id.org/smn/FishingType",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "FishingType", "en" : "Fishing type" },
       "subClasses" : [ "166" ],
       "attributes" : [ "external" ],
@@ -2493,6 +2584,7 @@
       "iri" : "https://w3id.org/smn/orbitalLength",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "orbitalLength", "en" : "Orbital length" },
       "attributes" : [ "external" ],
       "id" : "133",
@@ -2503,6 +2595,7 @@
       "equivalent" : [ "254" ],
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "FishLength", "en" : "Fish length" },
       "subClasses" : [ "133", "136", "138" ],
       "attributes" : [ "equivalent", "external" ],
@@ -2513,6 +2606,7 @@
       "iri" : "https://w3id.org/smn/totalLength",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "totalLength", "en" : "Total length" },
       "attributes" : [ "external" ],
       "id" : "136",
@@ -2522,6 +2616,7 @@
       "iri" : "https://w3id.org/smn/standardLength",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "standardLength", "en" : "Standard length" },
       "attributes" : [ "external" ],
       "id" : "138",
@@ -2975,7 +3070,10 @@
           "iri" : "https://w3id.org/smn/LifePhaseScheme",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Life phase scheme", "type" : "label" } ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "definition" : [
@@ -2994,7 +3092,10 @@
           "iri" : "https://w3id.org/smn/MeasurementContextScheme",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Measurement context scheme", "type" : "label" } ],
             "definition" : [
               {
@@ -3016,7 +3117,10 @@
           "iri" : "https://w3id.org/smn/SalmonOriginScheme",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "prefLabel" : [
               { "identifier" : "prefLabel", "language" : "en", "value" : "Salmon origin scheme", "type" : "label" },
               { "identifier" : "prefLabel", "language" : "en", "value" : "Salmon Origin Scheme", "type" : "label" }
@@ -5894,15 +5998,6 @@
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceHigh",
           "baseIri" : "https://w3id.org/gcdfo/salmon",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
-            "inScheme" : [
-              {
-                "identifier" : "inScheme",
-                "language" : "undefined",
-                "value" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme",
-                "type" : "iri"
-              }
-            ],
             "IAO_0000115" : [
               {
                 "identifier" : "IAO_0000115",
@@ -5911,6 +6006,23 @@
                 "type" : "label"
               }
             ],
+            "definition" : [
+              {
+                "identifier" : "definition",
+                "language" : "en",
+                "value" : "Rapid status confidence category indicating that high-quality abundance metrics support the result.",
+                "type" : "label"
+              }
+            ],
+            "inScheme" : [
+              {
+                "identifier" : "inScheme",
+                "language" : "undefined",
+                "value" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme",
+                "type" : "iri"
+              }
+            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "High confidence", "type" : "label" } ],
             "theme" : [
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" },
@@ -5923,10 +6035,17 @@
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceLow",
           "baseIri" : "https://w3id.org/gcdfo/salmon",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
             "IAO_0000115" : [
               {
                 "identifier" : "IAO_0000115",
+                "language" : "en",
+                "value" : "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone).",
+                "type" : "label"
+              }
+            ],
+            "definition" : [
+              {
+                "identifier" : "definition",
                 "language" : "en",
                 "value" : "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone).",
                 "type" : "label"
@@ -5940,6 +6059,7 @@
                 "type" : "iri"
               }
             ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Low confidence", "type" : "label" } ],
             "theme" : [
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" },
@@ -5952,10 +6072,17 @@
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceMedium",
           "baseIri" : "https://w3id.org/gcdfo/salmon",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
             "IAO_0000115" : [
               {
                 "identifier" : "IAO_0000115",
+                "language" : "en",
+                "value" : "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information.",
+                "type" : "label"
+              }
+            ],
+            "definition" : [
+              {
+                "identifier" : "definition",
                 "language" : "en",
                 "value" : "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information.",
                 "type" : "label"
@@ -5969,6 +6096,7 @@
                 "type" : "iri"
               }
             ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Medium confidence", "type" : "label" } ],
             "theme" : [
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" },
@@ -6978,7 +7106,10 @@
           "iri" : "https://w3id.org/smn/CatchContext",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContextScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Catch context", "type" : "label" } ],
             "definition" : [
@@ -6998,7 +7129,10 @@
           "iri" : "https://w3id.org/smn/HatcheryOrigin",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/SalmonOriginScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Hatchery-origin", "type" : "label" } ],
             "IAO_0000119" : [
@@ -7048,7 +7182,10 @@
           "iri" : "https://w3id.org/smn/InRiverPhase",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhaseScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "In-river phase", "type" : "label" } ],
             "definition" : [
@@ -7069,7 +7206,10 @@
           "iri" : "https://w3id.org/smn/LifePhase",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhaseScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Life phase", "type" : "label" } ],
             "definition" : [
@@ -7088,7 +7228,10 @@
           "iri" : "https://w3id.org/smn/MainstemPhase",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhaseScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Mainstem phase", "type" : "label" } ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
@@ -7108,7 +7251,10 @@
           "iri" : "https://w3id.org/smn/MeasurementContext",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContextScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Measurement context", "type" : "label" } ],
             "theme" : [
@@ -7136,7 +7282,10 @@
           "iri" : "https://w3id.org/smn/NaturalOrigin",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/SalmonOriginScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Natural-origin", "type" : "label" } ],
             "IAO_0000119" : [
@@ -7181,7 +7330,10 @@
           "iri" : "https://w3id.org/smn/OceanPhase",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhaseScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Ocean phase", "type" : "label" } ],
             "definition" : [
@@ -7202,7 +7354,10 @@
           "iri" : "https://w3id.org/smn/RunContext",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContextScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Run context", "type" : "label" } ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
@@ -7222,7 +7377,10 @@
           "iri" : "https://w3id.org/smn/SalmonOrigin",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/SalmonOriginScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Salmon origin", "type" : "label" } ],
             "theme" : [
@@ -7249,7 +7407,10 @@
           "iri" : "https://w3id.org/smn/SpawnerStageContext",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContextScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Spawner stage context", "type" : "label" } ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
@@ -7269,7 +7430,10 @@
           "iri" : "https://w3id.org/smn/SurvivalOrMortalityContext",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContextScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Survival or mortality context", "type" : "label" } ],
             "definition" : [
@@ -7289,7 +7453,10 @@
           "iri" : "https://w3id.org/smn/TerminalPhase",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+            "isDefinedBy" : [
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+            ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhaseScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Terminal phase", "type" : "label" } ],
             "definition" : [
@@ -7368,6 +7535,7 @@
       "iri" : "https://w3id.org/smn/StandardLengthMeasurement",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "StandardLengthMeasurement", "en" : "Standard length measurement" },
       "attributes" : [ "external" ],
       "id" : "147",
@@ -7610,6 +7778,7 @@
       "iri" : "https://w3id.org/smn/TotalLengthMeasurement",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "TotalLengthMeasurement", "en" : "Total length measurement" },
       "attributes" : [ "external" ],
       "id" : "161",
@@ -7632,6 +7801,7 @@
       "iri" : "https://w3id.org/smn/seiningEvent",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "seiningEvent", "en" : "Seining event" },
       "attributes" : [ "external" ],
       "id" : "166",
@@ -7641,6 +7811,7 @@
       "iri" : "https://w3id.org/smn/SalmonStockUnit",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "SalmonStockUnit", "en" : "Salmon stock unit" },
       "attributes" : [ "external" ],
       "id" : "170",
@@ -7720,7 +7891,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -7829,6 +8003,7 @@
       "iri" : "https://w3id.org/smn/ForkLengthMeasurementMethod",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "ForkLengthMeasurementMethod", "en" : "Fork-length measurement method" },
       "subClasses" : [ "190", "191" ],
       "attributes" : [ "external" ],
@@ -7839,6 +8014,7 @@
       "iri" : "https://w3id.org/smn/FishForkLengthMeasurementMethod",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "FishForkLengthMeasurementMethod", "en" : "Fish fork-length measurement method" },
       "subClasses" : [ "188" ],
       "attributes" : [ "external" ],
@@ -7849,6 +8025,7 @@
       "iri" : "https://w3id.org/smn/ForkLengthMeasurementFieldMethod",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "ForkLengthMeasurementFieldMethod", "en" : "Fork-length field method" },
       "attributes" : [ "external" ],
       "id" : "190",
@@ -7858,6 +8035,7 @@
       "iri" : "https://w3id.org/smn/ForkLengthMeasurementLabMethod",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "ForkLengthMeasurementLabMethod", "en" : "Fork-length lab method" },
       "attributes" : [ "external" ],
       "id" : "191",
@@ -7869,7 +8047,10 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -8013,6 +8194,7 @@
       "iri" : "https://w3id.org/smn/SalmonPopulationGroup",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "SalmonPopulationGroup", "en" : "Salmon population group" },
       "attributes" : [ "external" ],
       "id" : "210",
@@ -8084,6 +8266,7 @@
       "iri" : "https://w3id.org/smn/FishLengthMeasurementMethod",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "FishLengthMeasurementMethod", "en" : "Fish length measurement method" },
       "subClasses" : [ "189" ],
       "attributes" : [ "external" ],
@@ -8095,18 +8278,20 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
-        "inScheme" : [
-          { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EnumerationMethodScheme", "type" : "iri" }
-        ],
-        "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Enumeration Method", "type" : "label" } ],
-        "theme" : [
-          { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#MonitoringFieldWorkTheme", "type" : "iri" },
-          { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" }
+        "IAO_0000115" : [
+          { "identifier" : "IAO_0000115", "language" : "en", "value" : "A method used to enumerate or count salmon in the field", "type" : "label" }
         ],
         "definition" : [
           { "identifier" : "definition", "language" : "en", "value" : "A method used to enumerate or count salmon in the field", "type" : "label" }
         ],
+        "inScheme" : [
+          { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EnumerationMethodScheme", "type" : "iri" }
+        ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
+        "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Enumeration Method", "type" : "label" } ],
         "scopeNote" : [
           {
             "identifier" : "scopeNote",
@@ -8114,6 +8299,10 @@
             "value" : "DFO profile note: this ontology uses the shared `smn:EnumerationMethod` concept directly and constrains local narrower methods beneath it.",
             "type" : "label"
           }
+        ],
+        "theme" : [
+          { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#MonitoringFieldWorkTheme", "type" : "iri" },
+          { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" }
         ]
       },
       "label" : { "IRI-based" : "EnumerationMethod", "en" : "Enumeration Method" },
@@ -8137,6 +8326,7 @@
       "iri" : "https://w3id.org/smn/FishWeight",
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "FishWeight", "en" : "Fish weight" },
       "attributes" : [ "external" ],
       "id" : "224",
@@ -8178,10 +8368,17 @@
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceLow",
           "baseIri" : "https://w3id.org/gcdfo/salmon",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
             "IAO_0000115" : [
               {
                 "identifier" : "IAO_0000115",
+                "language" : "en",
+                "value" : "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone).",
+                "type" : "label"
+              }
+            ],
+            "definition" : [
+              {
+                "identifier" : "definition",
                 "language" : "en",
                 "value" : "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone).",
                 "type" : "label"
@@ -8195,6 +8392,7 @@
                 "type" : "iri"
               }
             ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Low confidence", "type" : "label" } ],
             "theme" : [
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" },
@@ -8207,10 +8405,17 @@
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceMedium",
           "baseIri" : "https://w3id.org/gcdfo/salmon",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
             "IAO_0000115" : [
               {
                 "identifier" : "IAO_0000115",
+                "language" : "en",
+                "value" : "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information.",
+                "type" : "label"
+              }
+            ],
+            "definition" : [
+              {
+                "identifier" : "definition",
                 "language" : "en",
                 "value" : "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information.",
                 "type" : "label"
@@ -8224,6 +8429,7 @@
                 "type" : "iri"
               }
             ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Medium confidence", "type" : "label" } ],
             "theme" : [
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" },
@@ -8236,15 +8442,6 @@
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceHigh",
           "baseIri" : "https://w3id.org/gcdfo/salmon",
           "annotations" : {
-            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
-            "inScheme" : [
-              {
-                "identifier" : "inScheme",
-                "language" : "undefined",
-                "value" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme",
-                "type" : "iri"
-              }
-            ],
             "IAO_0000115" : [
               {
                 "identifier" : "IAO_0000115",
@@ -8253,6 +8450,23 @@
                 "type" : "label"
               }
             ],
+            "definition" : [
+              {
+                "identifier" : "definition",
+                "language" : "en",
+                "value" : "Rapid status confidence category indicating that high-quality abundance metrics support the result.",
+                "type" : "label"
+              }
+            ],
+            "inScheme" : [
+              {
+                "identifier" : "inScheme",
+                "language" : "undefined",
+                "value" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceScheme",
+                "type" : "iri"
+              }
+            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "High confidence", "type" : "label" } ],
             "theme" : [
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" },
@@ -8425,6 +8639,7 @@
       "equivalent" : [ "134" ],
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "forkLength", "en" : "Fork length" },
       "attributes" : [ "equivalent", "external" ],
       "id" : "254"
@@ -9281,7 +9496,10 @@
       "baseIri" : "https://w3id.org/smn",
       "range" : "33",
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [ { "identifier" : "IAO_0000115", "language" : "en", "value" : "Relates a population to one of its constituent demes.", "type" : "label" } ],
         "theme" : [
           { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" },
@@ -9368,7 +9586,10 @@
       "baseIri" : "https://w3id.org/smn",
       "range" : "32",
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -9404,6 +9625,7 @@
       "iri" : "https://w3id.org/smn/characteristicFor",
       "baseIri" : "https://w3id.org/smn",
       "range" : "60",
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "characteristicFor", "en" : "characteristic for" },
       "domain" : "17",
       "attributes" : [ "external", "object" ],
@@ -9445,6 +9667,7 @@
       "iri" : "https://w3id.org/smn/observedTaxonSpecies",
       "baseIri" : "https://w3id.org/smn",
       "range" : "56",
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "observedTaxonSpecies", "en" : "observed taxon species" },
       "domain" : "40",
       "attributes" : [ "external", "object" ],
@@ -9689,7 +9912,10 @@
       "baseIri" : "https://w3id.org/smn",
       "range" : "32",
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [ { "identifier" : "IAO_0000115", "language" : "en", "value" : "Relates a deme to the population it belongs to.", "type" : "label" } ],
         "theme" : [
           { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" },
@@ -9756,7 +9982,10 @@
       "baseIri" : "https://w3id.org/smn",
       "range" : "229",
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
+          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
+        ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -9819,8 +10048,8 @@
       "attributes" : [ "external", "object" ],
       "id" : "232"
     },
-    { "domain" : "142", "range" : "222", "id" : "234", "label" : { "IRI-based" : "15", "undefined" : "is a" } },
-    { "domain" : "142", "range" : "236", "id" : "235", "label" : { "IRI-based" : "16", "undefined" : "is a" } },
+    { "domain" : "142", "range" : "222", "id" : "234", "label" : { "IRI-based" : "16", "undefined" : "is a" } },
+    { "domain" : "142", "range" : "236", "id" : "235", "label" : { "IRI-based" : "14", "undefined" : "is a" } },
     {
       "iri" : "https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint",
       "inverse" : "238",
@@ -9930,6 +10159,7 @@
       "iri" : "https://w3id.org/smn/basedOn",
       "baseIri" : "https://w3id.org/smn",
       "range" : "222",
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "basedOn", "en" : "based on" },
       "domain" : "83",
       "attributes" : [ "external", "object" ],
@@ -9999,6 +10229,7 @@
       "iri" : "https://w3id.org/smn/observedTaxonFamily",
       "baseIri" : "https://w3id.org/smn",
       "range" : "145",
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "observedTaxonFamily", "en" : "observed taxon family" },
       "domain" : "40",
       "attributes" : [ "external", "object" ],
@@ -10027,6 +10258,7 @@
       "iri" : "https://w3id.org/smn/hasMeasurement",
       "baseIri" : "https://w3id.org/smn",
       "range" : "81",
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "hasMeasurement", "en" : "has measurement" },
       "domain" : "60",
       "attributes" : [ "external", "object" ],
@@ -10037,6 +10269,7 @@
       "iri" : "https://w3id.org/smn/hasEventType",
       "baseIri" : "https://w3id.org/smn",
       "range" : "128",
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "hasEventType", "en" : "has event type" },
       "domain" : "123",
       "attributes" : [ "external", "object" ],
@@ -10112,6 +10345,7 @@
       "iri" : "https://w3id.org/smn/basedOn",
       "baseIri" : "https://w3id.org/smn",
       "range" : "222",
+      "annotations" : { "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ] },
       "label" : { "IRI-based" : "basedOn", "en" : "based on" },
       "domain" : "83",
       "attributes" : [ "external", "object", "someValues" ],
@@ -10140,7 +10374,7 @@
     { "range" : "43", "domain" : "1", "attributes" : [ "anonymous", "object" ], "id" : "334" },
     { "range" : "43", "domain" : "248", "attributes" : [ "anonymous", "object" ], "id" : "335" },
     { "range" : "43", "domain" : "116", "attributes" : [ "anonymous", "object" ], "id" : "336" },
-    { "domain" : "142", "range" : "339", "id" : "342", "label" : { "IRI-based" : "14", "undefined" : "is a" } },
+    { "domain" : "142", "range" : "339", "id" : "342", "label" : { "IRI-based" : "15", "undefined" : "is a" } },
     { "range" : "99", "domain" : "340", "attributes" : [ "anonymous", "object" ], "id" : "343" },
     { "range" : "99", "domain" : "341", "attributes" : [ "anonymous", "object" ], "id" : "344" }
   ]

--- a/docs/webvowl/data/ontology.json
+++ b/docs/webvowl/data/ontology.json
@@ -290,10 +290,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -340,10 +337,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -486,10 +480,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -548,10 +539,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -855,10 +843,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "closeMatch" : [ { "identifier" : "closeMatch", "language" : "undefined", "value" : "http://www.w3.org/ns/sosa/FeatureOfInterest", "type" : "iri" } ],
         "IAO_0000115" : [
           {
@@ -890,10 +875,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -930,10 +912,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -1068,10 +1047,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -1412,10 +1388,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -1447,10 +1420,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -1702,10 +1672,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "closeMatch" : [ { "identifier" : "closeMatch", "language" : "undefined", "value" : "http://www.w3.org/ns/sosa/FeatureOfInterest", "type" : "iri" } ],
         "IAO_0000115" : [
           {
@@ -1791,10 +1758,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -1864,10 +1828,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           { "identifier" : "IAO_0000115", "language" : "en", "value" : "A survey event specifically for estimating escapement.", "type" : "label" }
         ],
@@ -1960,10 +1921,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -2191,10 +2149,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -3070,10 +3025,7 @@
           "iri" : "https://w3id.org/smn/LifePhaseScheme",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Life phase scheme", "type" : "label" } ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "definition" : [
@@ -3092,10 +3044,7 @@
           "iri" : "https://w3id.org/smn/MeasurementContextScheme",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Measurement context scheme", "type" : "label" } ],
             "definition" : [
               {
@@ -3117,10 +3066,7 @@
           "iri" : "https://w3id.org/smn/SalmonOriginScheme",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "prefLabel" : [
               { "identifier" : "prefLabel", "language" : "en", "value" : "Salmon origin scheme", "type" : "label" },
               { "identifier" : "prefLabel", "language" : "en", "value" : "Salmon Origin Scheme", "type" : "label" }
@@ -7106,10 +7052,7 @@
           "iri" : "https://w3id.org/smn/CatchContext",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContextScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Catch context", "type" : "label" } ],
             "definition" : [
@@ -7129,10 +7072,7 @@
           "iri" : "https://w3id.org/smn/HatcheryOrigin",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/SalmonOriginScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Hatchery-origin", "type" : "label" } ],
             "IAO_0000119" : [
@@ -7182,10 +7122,7 @@
           "iri" : "https://w3id.org/smn/InRiverPhase",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhaseScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "In-river phase", "type" : "label" } ],
             "definition" : [
@@ -7206,10 +7143,7 @@
           "iri" : "https://w3id.org/smn/LifePhase",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhaseScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Life phase", "type" : "label" } ],
             "definition" : [
@@ -7228,10 +7162,7 @@
           "iri" : "https://w3id.org/smn/MainstemPhase",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhaseScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Mainstem phase", "type" : "label" } ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
@@ -7251,10 +7182,7 @@
           "iri" : "https://w3id.org/smn/MeasurementContext",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContextScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Measurement context", "type" : "label" } ],
             "theme" : [
@@ -7282,10 +7210,7 @@
           "iri" : "https://w3id.org/smn/NaturalOrigin",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/SalmonOriginScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Natural-origin", "type" : "label" } ],
             "IAO_0000119" : [
@@ -7330,10 +7255,7 @@
           "iri" : "https://w3id.org/smn/OceanPhase",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhaseScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Ocean phase", "type" : "label" } ],
             "definition" : [
@@ -7354,10 +7276,7 @@
           "iri" : "https://w3id.org/smn/RunContext",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContextScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Run context", "type" : "label" } ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
@@ -7377,10 +7296,7 @@
           "iri" : "https://w3id.org/smn/SalmonOrigin",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/SalmonOriginScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Salmon origin", "type" : "label" } ],
             "theme" : [
@@ -7407,10 +7323,7 @@
           "iri" : "https://w3id.org/smn/SpawnerStageContext",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContextScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Spawner stage context", "type" : "label" } ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
@@ -7430,10 +7343,7 @@
           "iri" : "https://w3id.org/smn/SurvivalOrMortalityContext",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContextScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Survival or mortality context", "type" : "label" } ],
             "definition" : [
@@ -7453,10 +7363,7 @@
           "iri" : "https://w3id.org/smn/TerminalPhase",
           "baseIri" : "https://w3id.org/smn",
           "annotations" : {
-            "isDefinedBy" : [
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-              { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-            ],
+            "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
             "inScheme" : [ { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhaseScheme", "type" : "iri" } ],
             "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Terminal phase", "type" : "label" } ],
             "definition" : [
@@ -7856,7 +7763,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" } ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "closeMatch" : [ { "identifier" : "closeMatch", "language" : "undefined", "value" : "https://w3id.org/iadopt/ont/Constraint", "type" : "iri" } ],
         "IAO_0000115" : [
           {
@@ -7891,10 +7798,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -8047,10 +7951,7 @@
       "baseIri" : "https://w3id.org/smn",
       "instances" : 0,
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -8287,10 +8188,7 @@
         "inScheme" : [
           { "identifier" : "inScheme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EnumerationMethodScheme", "type" : "iri" }
         ],
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "prefLabel" : [ { "identifier" : "prefLabel", "language" : "en", "value" : "Enumeration Method", "type" : "label" } ],
         "scopeNote" : [
           {
@@ -9496,10 +9394,7 @@
       "baseIri" : "https://w3id.org/smn",
       "range" : "33",
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [ { "identifier" : "IAO_0000115", "language" : "en", "value" : "Relates a population to one of its constituent demes.", "type" : "label" } ],
         "theme" : [
           { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" },
@@ -9586,10 +9481,7 @@
       "baseIri" : "https://w3id.org/smn",
       "range" : "32",
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -9912,10 +9804,7 @@
       "baseIri" : "https://w3id.org/smn",
       "range" : "32",
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [ { "identifier" : "IAO_0000115", "language" : "en", "value" : "Relates a deme to the population it belongs to.", "type" : "label" } ],
         "theme" : [
           { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" },
@@ -9982,10 +9871,7 @@
       "baseIri" : "https://w3id.org/smn",
       "range" : "229",
       "annotations" : {
-        "isDefinedBy" : [
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon", "type" : "iri" },
-          { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" }
-        ],
+        "isDefinedBy" : [ { "identifier" : "isDefinedBy", "language" : "undefined", "value" : "https://w3id.org/smn", "type" : "iri" } ],
         "IAO_0000115" : [
           {
             "identifier" : "IAO_0000115",
@@ -10048,8 +9934,8 @@
       "attributes" : [ "external", "object" ],
       "id" : "232"
     },
-    { "domain" : "142", "range" : "222", "id" : "234", "label" : { "IRI-based" : "16", "undefined" : "is a" } },
-    { "domain" : "142", "range" : "236", "id" : "235", "label" : { "IRI-based" : "14", "undefined" : "is a" } },
+    { "domain" : "142", "range" : "222", "id" : "234", "label" : { "IRI-based" : "14", "undefined" : "is a" } },
+    { "domain" : "142", "range" : "236", "id" : "235", "label" : { "IRI-based" : "16", "undefined" : "is a" } },
     {
       "iri" : "https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint",
       "inverse" : "238",
@@ -10103,7 +9989,7 @@
       "id" : "238",
       "inverse" : "237"
     },
-    { "domain" : "142", "range" : "24", "id" : "240", "label" : { "IRI-based" : "13", "undefined" : "is a" } },
+    { "domain" : "142", "range" : "24", "id" : "240", "label" : { "IRI-based" : "15", "undefined" : "is a" } },
     {
       "iri" : "https://w3id.org/gcdfo/salmon#hasObservedVariable",
       "baseIri" : "https://w3id.org/gcdfo/salmon",
@@ -10374,7 +10260,7 @@
     { "range" : "43", "domain" : "1", "attributes" : [ "anonymous", "object" ], "id" : "334" },
     { "range" : "43", "domain" : "248", "attributes" : [ "anonymous", "object" ], "id" : "335" },
     { "range" : "43", "domain" : "116", "attributes" : [ "anonymous", "object" ], "id" : "336" },
-    { "domain" : "142", "range" : "339", "id" : "342", "label" : { "IRI-based" : "15", "undefined" : "is a" } },
+    { "domain" : "142", "range" : "339", "id" : "342", "label" : { "IRI-based" : "13", "undefined" : "is a" } },
     { "range" : "99", "domain" : "340", "attributes" : [ "anonymous", "object" ], "id" : "343" },
     { "range" : "99", "domain" : "341", "attributes" : [ "anonymous", "object" ], "id" : "344" }
   ]

--- a/docs/webvowl/data/ontology.json
+++ b/docs/webvowl/data/ontology.json
@@ -656,7 +656,7 @@
           }
         ]
       },
-      "label" : { "IRI-based" : "WSPBiologicalStatusZone" },
+      "label" : { "IRI-based" : "WSPBiologicalStatusZone", "en" : "Wild Salmon Policy biological status zone" },
       "individuals" : [
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RedZone",
@@ -708,7 +708,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "RedZone" }
+          "labels" : { "IRI-based" : "RedZone", "en" : "Red zone" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#GreenZone",
@@ -760,7 +760,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "GreenZone" }
+          "labels" : { "IRI-based" : "GreenZone", "en" : "Green zone" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AmberZone",
@@ -812,7 +812,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "AmberZone" }
+          "labels" : { "IRI-based" : "AmberZone", "en" : "Amber zone" }
         }
       ],
       "id" : "24"
@@ -3235,7 +3235,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "AbsoluteAbundanceMetricStatus" }
+          "labels" : { "IRI-based" : "AbsoluteAbundanceMetricStatus", "en" : "Absolute abundance metric status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AbundanceDataType",
@@ -3291,7 +3291,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "AbundanceDataType" }
+          "labels" : { "IRI-based" : "AbundanceDataType", "en" : "Abundance data type" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AbundancePercentileMetric",
@@ -3353,7 +3353,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "AbundancePercentileMetric" }
+          "labels" : { "IRI-based" : "AbundancePercentileMetric", "en" : "Abundance percentile metric" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AbundancePercentileMetricStatus",
@@ -3413,7 +3413,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "AbundancePercentileMetricStatus" }
+          "labels" : { "IRI-based" : "AbundancePercentileMetricStatus", "en" : "Abundance percentile metric status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AerialSurveyCount",
@@ -3439,7 +3439,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/EnumerationMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Legacy methods: Helicopter, Fixed Wing Aircraft, Aerial, Drone, UAS, UAV" },
-          "labels" : { "IRI-based" : "AerialSurveyCount" }
+          "labels" : { "IRI-based" : "AerialSurveyCount", "en" : "Aerial Survey Count" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Age1YearClass",
@@ -3453,7 +3453,7 @@
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeClassValue", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Age1YearClass" }
+          "labels" : { "IRI-based" : "Age1YearClass", "en" : "Age 1 year class" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Age2YearClass",
@@ -3467,7 +3467,7 @@
             "definition" : [ { "identifier" : "definition", "language" : "en", "value" : "Age class value 2 years.", "type" : "label" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeClassValue", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Age2YearClass" }
+          "labels" : { "IRI-based" : "Age2YearClass", "en" : "Age 2 year class" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Age3YearClass",
@@ -3481,7 +3481,7 @@
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeClassValue", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Age3YearClass" }
+          "labels" : { "IRI-based" : "Age3YearClass", "en" : "Age 3 year class" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Age4YearClass",
@@ -3495,7 +3495,7 @@
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeClassValue", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Age4YearClass" }
+          "labels" : { "IRI-based" : "Age4YearClass", "en" : "Age 4 year class" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Age5YearClass",
@@ -3509,7 +3509,7 @@
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeClassValue", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Age5YearClass" }
+          "labels" : { "IRI-based" : "Age5YearClass", "en" : "Age 5 year class" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Age6YearClass",
@@ -3523,7 +3523,7 @@
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeClassValue", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Age6YearClass" }
+          "labels" : { "IRI-based" : "Age6YearClass", "en" : "Age 6 year class" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Age7YearClass",
@@ -3537,7 +3537,7 @@
             "definition" : [ { "identifier" : "definition", "language" : "en", "value" : "Age class value 7 years.", "type" : "label" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeClassValue", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Age7YearClass" }
+          "labels" : { "IRI-based" : "Age7YearClass", "en" : "Age 7 year class" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AgeAtMaturityBasis",
@@ -3553,7 +3553,7 @@
             "definition" : [ { "identifier" : "definition", "language" : "en", "value" : "Age measured at maturity.", "type" : "label" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeBasis", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "AgeAtMaturityBasis" }
+          "labels" : { "IRI-based" : "AgeAtMaturityBasis", "en" : "Age at maturity basis" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AgeAtReturnBasis",
@@ -3571,7 +3571,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeBasis", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "AgeAtReturnBasis" }
+          "labels" : { "IRI-based" : "AgeAtReturnBasis", "en" : "Age at return basis" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AgeAtSamplingBasis",
@@ -3587,7 +3587,7 @@
             "definition" : [ { "identifier" : "definition", "language" : "en", "value" : "Age measured at the time of sampling or observation.", "type" : "label" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeBasis", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "AgeAtSamplingBasis" }
+          "labels" : { "IRI-based" : "AgeAtSamplingBasis", "en" : "Age at sampling basis" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AgeBasis",
@@ -3609,7 +3609,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "AgeBasis" }
+          "labels" : { "IRI-based" : "AgeBasis", "en" : "Age basis" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AgeClassValue",
@@ -3628,7 +3628,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "AgeClassValue" }
+          "labels" : { "IRI-based" : "AgeClassValue", "en" : "Age class value" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AgeDimension",
@@ -3647,7 +3647,7 @@
             ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "AgeDimension" }
+          "labels" : { "IRI-based" : "AgeDimension", "en" : "Age dimension" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AgeNotation",
@@ -3669,7 +3669,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "AgeNotation" }
+          "labels" : { "IRI-based" : "AgeNotation", "en" : "Age notation" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AmberZone",
@@ -3721,7 +3721,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "AmberZone" }
+          "labels" : { "IRI-based" : "AmberZone", "en" : "Amber zone" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AreaUnderTheCurve",
@@ -3745,7 +3745,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EstimateMethod", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "AreaUnderTheCurve" }
+          "labels" : { "IRI-based" : "AreaUnderTheCurve", "en" : "Area Under the Curve" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#BenchmarkRatioMetric",
@@ -3808,7 +3808,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#RapidStatusMetric", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "BenchmarkRatioMetric" }
+          "labels" : { "IRI-based" : "BenchmarkRatioMetric", "en" : "Benchmark ratio metric" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#BreachBypass",
@@ -3834,7 +3834,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 2 maximum" },
-          "labels" : { "IRI-based" : "BreachBypass" }
+          "labels" : { "IRI-based" : "BreachBypass", "en" : "Bypass/Breach Risk" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#BroodYear",
@@ -3882,7 +3882,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "BroodYear" }
+          "labels" : { "IRI-based" : "BroodYear", "en" : "Brood year" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#CalibratedTimeSeries",
@@ -3906,7 +3906,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EstimateMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Document calibration source years, transferability, diagnostics. Type-2 when calibration robust and applicable; else Type-3." },
-          "labels" : { "IRI-based" : "CalibratedTimeSeries" }
+          "labels" : { "IRI-based" : "CalibratedTimeSeries", "en" : "Calibrated Time Series" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#CatchYear",
@@ -3937,7 +3937,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#YearBasis", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "CatchYear" }
+          "labels" : { "IRI-based" : "CatchYear", "en" : "Catch year" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Classification",
@@ -3956,7 +3956,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 3 maximum" },
-          "labels" : { "IRI-based" : "Classification" }
+          "labels" : { "IRI-based" : "Classification", "en" : "Classification" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#ConservationUnitName",
@@ -4000,7 +4000,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "ConservationUnitName" }
+          "labels" : { "IRI-based" : "ConservationUnitName", "en" : "Conservation Unit name" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#CrossSectionCoverage",
@@ -4019,7 +4019,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 2 maximum" },
-          "labels" : { "IRI-based" : "CrossSectionCoverage" }
+          "labels" : { "IRI-based" : "CrossSectionCoverage", "en" : "Cross-section Coverage" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme",
@@ -4038,7 +4038,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "DataModelProvenanceTheme" }
+          "labels" : { "IRI-based" : "DataModelProvenanceTheme", "en" : "Data, Models, and Provenance" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#DataQualityRatingContext",
@@ -4058,7 +4058,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContext", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "DataQualityRatingContext" }
+          "labels" : { "IRI-based" : "DataQualityRatingContext", "en" : "Data quality rating context" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Detectability",
@@ -4077,7 +4077,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 3 maximum" },
-          "labels" : { "IRI-based" : "Detectability" }
+          "labels" : { "IRI-based" : "Detectability", "en" : "Detectability" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#DeviceConfiguration",
@@ -4096,7 +4096,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 2 maximum" },
-          "labels" : { "IRI-based" : "DeviceConfiguration" }
+          "labels" : { "IRI-based" : "DeviceConfiguration", "en" : "Device Configuration" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Documentation",
@@ -4115,7 +4115,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Downgrades Type 1/2 by one level" },
-          "labels" : { "IRI-based" : "Documentation" }
+          "labels" : { "IRI-based" : "Documentation", "en" : "Documentation" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria",
@@ -4139,7 +4139,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "DowngradeCriteria" }
+          "labels" : { "IRI-based" : "DowngradeCriteria", "en" : "Downgrade Criteria" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#EffortStandardization",
@@ -4158,7 +4158,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 4 maximum" },
-          "labels" : { "IRI-based" : "EffortStandardization" }
+          "labels" : { "IRI-based" : "EffortStandardization", "en" : "Effort Standardization" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#ElectrofishingCount",
@@ -4184,7 +4184,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/EnumerationMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Legacy methods: Electrofishing, Electroshocking" },
-          "labels" : { "IRI-based" : "ElectrofishingCount" }
+          "labels" : { "IRI-based" : "ElectrofishingCount", "en" : "Electrofishing Count" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#EnvironmentalConditions",
@@ -4203,7 +4203,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 2 maximum" },
-          "labels" : { "IRI-based" : "EnvironmentalConditions" }
+          "labels" : { "IRI-based" : "EnvironmentalConditions", "en" : "Environmental Conditions" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#EstimateMethod",
@@ -4225,7 +4225,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "EstimateMethod" }
+          "labels" : { "IRI-based" : "EstimateMethod", "en" : "Estimate Method" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#EstimateType",
@@ -4247,7 +4247,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "EstimateType" }
+          "labels" : { "IRI-based" : "EstimateType", "en" : "Estimate Type" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#EuropeanAgeNotation",
@@ -4279,7 +4279,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeNotation", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "EuropeanAgeNotation" }
+          "labels" : { "IRI-based" : "EuropeanAgeNotation", "en" : "European age notation" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#ExpansionFactor",
@@ -4328,7 +4328,7 @@
               { "identifier" : "source", "language" : "undefined", "value" : "https://waves-vagues.dfo-mpo.gc.ca/Library/40978680.pdf", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "ExpansionFactor" }
+          "labels" : { "IRI-based" : "ExpansionFactor", "en" : "Expansion factor" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#ExpansionMathematicalOperations",
@@ -4354,7 +4354,7 @@
           "comment" : {
             "en" : "Legacy methods: Lake Expansion, Redd Expansion, Peak×Factor, (Peak+CumDead)×Factor, Addition/Subtraction, Multiplication/Division. Inherits base method's Type; weak provenance = downgrade one Type."
           },
-          "labels" : { "IRI-based" : "ExpansionMathematicalOperations" }
+          "labels" : { "IRI-based" : "ExpansionMathematicalOperations", "en" : "Expansion/Mathematical Operations" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#FishStockProvisions",
@@ -4379,7 +4379,7 @@
             "altLabel" : [ { "identifier" : "altLabel", "language" : "en", "value" : "FSP", "type" : "label" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#PolicyFramework", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "FishStockProvisions" }
+          "labels" : { "IRI-based" : "FishStockProvisions", "en" : "Fish Stocks Provisions" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#FisheriesManagementTheme",
@@ -4398,7 +4398,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "FisheriesManagementTheme" }
+          "labels" : { "IRI-based" : "FisheriesManagementTheme", "en" : "Fisheries Management" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#FixedSiteCensusElectronic",
@@ -4424,7 +4424,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/EnumerationMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Legacy methods: Electronic/Optical counter, Resistivity Counter, Video/Camera counter" },
-          "labels" : { "IRI-based" : "FixedSiteCensusElectronic" }
+          "labels" : { "IRI-based" : "FixedSiteCensusElectronic", "en" : "Fixed Site Census (Electronic)" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#FixedSiteCensusManual",
@@ -4450,7 +4450,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/EnumerationMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Legacy methods: Fence, Weir, Fixed Site Census (manual)" },
-          "labels" : { "IRI-based" : "FixedSiteCensusManual" }
+          "labels" : { "IRI-based" : "FixedSiteCensusManual", "en" : "Fixed Site Census (Manual)" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#FixedStationTally",
@@ -4473,7 +4473,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EstimateMethod", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "FixedStationTally" }
+          "labels" : { "IRI-based" : "FixedStationTally", "en" : "Fixed‑Station Tally" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#FreshwaterAgeDimension",
@@ -4486,7 +4486,7 @@
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeDimension", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "FreshwaterAgeDimension" }
+          "labels" : { "IRI-based" : "FreshwaterAgeDimension", "en" : "Freshwater age dimension" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#GenerationalAverageAbundance",
@@ -4541,7 +4541,7 @@
               { "identifier" : "iadoptProperty", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#SpawnerAbundance", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "GenerationalAverageAbundance" }
+          "labels" : { "IRI-based" : "GenerationalAverageAbundance", "en" : "Generational average abundance" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#GeneticsStockCompositionTheme",
@@ -4560,7 +4560,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "GeneticsStockCompositionTheme" }
+          "labels" : { "IRI-based" : "GeneticsStockCompositionTheme", "en" : "Genetics and Stock Composition" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#GilbertRichAgeNotation",
@@ -4593,7 +4593,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "GilbertRichAgeNotation" }
+          "labels" : { "IRI-based" : "GilbertRichAgeNotation", "en" : "Gilbert-Rich age notation" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#GreenZone",
@@ -4645,7 +4645,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "GreenZone" }
+          "labels" : { "IRI-based" : "GreenZone", "en" : "Green zone" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#HabitatEcosystemClimateTheme",
@@ -4664,7 +4664,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "HabitatEcosystemClimateTheme" }
+          "labels" : { "IRI-based" : "HabitatEcosystemClimateTheme", "en" : "Habitat, Ecosystem, and Climate Pressures" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#HydroacousticModelling",
@@ -4690,7 +4690,7 @@
           "comment" : {
             "en" : "Legacy methods: Hydroacoustics, Sonar (ARIS/DIDSON). Not Type-1 under Hyatt; interpolation and classification error are central downgrades."
           },
-          "labels" : { "IRI-based" : "HydroacousticModelling" }
+          "labels" : { "IRI-based" : "HydroacousticModelling", "en" : "Hydroacoustic Modelling" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#HydroacousticSonarCount",
@@ -4716,7 +4716,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/EnumerationMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Legacy methods: Sonar-ARIS, Sonar-DIDSON, Hydroacoustic" },
-          "labels" : { "IRI-based" : "HydroacousticSonarCount" }
+          "labels" : { "IRI-based" : "HydroacousticSonarCount", "en" : "Hydroacoustic Sonar Count" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#InfillMethod",
@@ -4742,7 +4742,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 2 maximum" },
-          "labels" : { "IRI-based" : "InfillMethod" }
+          "labels" : { "IRI-based" : "InfillMethod", "en" : "Infill Method" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusAmberGreen",
@@ -4793,7 +4793,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusAmberGreen" }
+          "labels" : { "IRI-based" : "IntegratedStatusAmberGreen", "en" : "Amber/Green integrated status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusBinary",
@@ -4840,7 +4840,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusBinary" }
+          "labels" : { "IRI-based" : "IntegratedStatusBinary", "en" : "Integrated status (binary red/not-red)" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusCollapsedCode",
@@ -4885,7 +4885,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusCollapsedCode" }
+          "labels" : { "IRI-based" : "IntegratedStatusCollapsedCode", "en" : "Collapsed integrated status code" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusDataDeficient",
@@ -4932,7 +4932,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusDataDeficient" }
+          "labels" : { "IRI-based" : "IntegratedStatusDataDeficient", "en" : "Data deficient integrated status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusFiveCategoryAlias",
@@ -4976,7 +4976,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusFiveCategoryAlias" }
+          "labels" : { "IRI-based" : "IntegratedStatusFiveCategoryAlias", "en" : "Integrated status (5-category legacy alias)" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusNotRed",
@@ -5015,7 +5015,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusNotRed" }
+          "labels" : { "IRI-based" : "IntegratedStatusNotRed", "en" : "Not-red integrated status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusRaw",
@@ -5070,7 +5070,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusRaw" }
+          "labels" : { "IRI-based" : "IntegratedStatusRaw", "en" : "Integrated status (raw)" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusRawCode",
@@ -5117,7 +5117,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusRawCode" }
+          "labels" : { "IRI-based" : "IntegratedStatusRawCode", "en" : "Raw integrated status code" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusRedAmber",
@@ -5168,7 +5168,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusRedAmber" }
+          "labels" : { "IRI-based" : "IntegratedStatusRedAmber", "en" : "Red/Amber integrated status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusThreeCategory",
@@ -5215,7 +5215,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusThreeCategory" }
+          "labels" : { "IRI-based" : "IntegratedStatusThreeCategory", "en" : "Integrated status (3-category collapsed)" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusUndetermined",
@@ -5263,7 +5263,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusUndetermined" }
+          "labels" : { "IRI-based" : "IntegratedStatusUndetermined", "en" : "Undetermined integrated status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#LongTermTrendMetric",
@@ -5325,7 +5325,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "LongTermTrendMetric" }
+          "labels" : { "IRI-based" : "LongTermTrendMetric", "en" : "Long-term trend metric" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#LongTermTrendMetricStatus",
@@ -5385,7 +5385,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "LongTermTrendMetricStatus" }
+          "labels" : { "IRI-based" : "LongTermTrendMetricStatus", "en" : "Long-term trend metric status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#LowerBenchmark",
@@ -5407,7 +5407,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "LowerBenchmark" }
+          "labels" : { "IRI-based" : "LowerBenchmark", "en" : "Lower benchmark" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#ManagementReferenceContext",
@@ -5430,7 +5430,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContext", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "ManagementReferenceContext" }
+          "labels" : { "IRI-based" : "ManagementReferenceContext", "en" : "Management reference context" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#MarkRecaptureAnalysis",
@@ -5456,7 +5456,7 @@
           "comment" : {
             "en" : "Legacy methods: Petersen, Jolly-Seber, Open model, Bayesian MR. Store uncertainty (e.g., CV) when available; note tag loss/recovery protocols."
           },
-          "labels" : { "IRI-based" : "MarkRecaptureAnalysis" }
+          "labels" : { "IRI-based" : "MarkRecaptureAnalysis", "en" : "Mark-Recapture Analysis" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#MarkRecaptureAssumptions",
@@ -5475,7 +5475,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 3 maximum" },
-          "labels" : { "IRI-based" : "MarkRecaptureAssumptions" }
+          "labels" : { "IRI-based" : "MarkRecaptureAssumptions", "en" : "Mark-Recapture Assumptions" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#MarkRecaptureFieldProgram",
@@ -5501,7 +5501,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/EnumerationMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Legacy methods: Tag Recovery" },
-          "labels" : { "IRI-based" : "MarkRecaptureFieldProgram" }
+          "labels" : { "IRI-based" : "MarkRecaptureFieldProgram", "en" : "Mark-Recapture Field Program" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#MethodUnknown",
@@ -5527,7 +5527,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 5 maximum" },
-          "labels" : { "IRI-based" : "MethodUnknown" }
+          "labels" : { "IRI-based" : "MethodUnknown", "en" : "Method Unknown/Inconsistent" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#MonitoringFieldWorkTheme",
@@ -5546,7 +5546,7 @@
             ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "MonitoringFieldWorkTheme" }
+          "labels" : { "IRI-based" : "MonitoringFieldWorkTheme", "en" : "Monitoring and Field Work" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#NumberOfVisits",
@@ -5565,7 +5565,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 4 maximum" },
-          "labels" : { "IRI-based" : "NumberOfVisits" }
+          "labels" : { "IRI-based" : "NumberOfVisits", "en" : "Number of Visits" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#OceanAgeDimension",
@@ -5586,7 +5586,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeDimension", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "OceanAgeDimension" }
+          "labels" : { "IRI-based" : "OceanAgeDimension", "en" : "Ocean age dimension" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#PeakCountAnalysis",
@@ -5610,7 +5610,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EstimateMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Legacy methods: Peak Live, Peak Live + Dead, Peak + Cumulative Dead, Cumulative New" },
-          "labels" : { "IRI-based" : "PeakCountAnalysis" }
+          "labels" : { "IRI-based" : "PeakCountAnalysis", "en" : "Peak Count Analysis" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#PercentChangeMetric",
@@ -5673,7 +5673,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#RapidStatusMetric", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "PercentChangeMetric" }
+          "labels" : { "IRI-based" : "PercentChangeMetric", "en" : "Percent change metric" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#PercentChangeMetricStatus",
@@ -5733,7 +5733,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "PercentChangeMetricStatus" }
+          "labels" : { "IRI-based" : "PercentChangeMetricStatus", "en" : "Percent change metric status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#PolicyFramework",
@@ -5756,7 +5756,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "PolicyFramework" }
+          "labels" : { "IRI-based" : "PolicyFramework", "en" : "Policy framework" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#PolicyGovernanceTheme",
@@ -5775,7 +5775,7 @@
             ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "PolicyGovernanceTheme" }
+          "labels" : { "IRI-based" : "PolicyGovernanceTheme", "en" : "Policy, Governance, and Organizational Structure" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#PrecautionaryApproach",
@@ -5800,7 +5800,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#PolicyFramework", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "PrecautionaryApproach" }
+          "labels" : { "IRI-based" : "PrecautionaryApproach", "en" : "Precautionary Approach" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#PrecisionAccuracy",
@@ -5819,7 +5819,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Downgrades by one level" },
-          "labels" : { "IRI-based" : "PrecisionAccuracy" }
+          "labels" : { "IRI-based" : "PrecisionAccuracy", "en" : "Precision/Accuracy" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#ProbabilityDeclineBelowLowerBenchmarkMetric",
@@ -5876,7 +5876,7 @@
               { "identifier" : "iadoptProperty", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#SpawnerAbundance", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "ProbabilityDeclineBelowLowerBenchmarkMetric" }
+          "labels" : { "IRI-based" : "ProbabilityDeclineBelowLowerBenchmarkMetric", "en" : "Probability of decline below lower benchmark metric" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#ProbabilityDeclineBelowLowerBenchmarkMetricStatus",
@@ -5938,7 +5938,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "ProbabilityDeclineBelowLowerBenchmarkMetricStatus" }
+          "labels" : { "IRI-based" : "ProbabilityDeclineBelowLowerBenchmarkMetricStatus", "en" : "Probability-of-decline-below-lower-benchmark metric status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceHigh",
@@ -5952,6 +5952,7 @@
                 "type" : "label"
               }
             ],
+            "altLabel" : [ { "identifier" : "altLabel", "language" : "en", "value" : "High rapid-status confidence", "type" : "label" } ],
             "definition" : [
               {
                 "identifier" : "definition",
@@ -5975,7 +5976,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "RapidStatusConfidenceHigh", "en" : "High rapid-status confidence" }
+          "labels" : { "IRI-based" : "RapidStatusConfidenceHigh", "en" : "High confidence" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceLow",
@@ -5989,6 +5990,7 @@
                 "type" : "label"
               }
             ],
+            "altLabel" : [ { "identifier" : "altLabel", "language" : "en", "value" : "Low rapid-status confidence", "type" : "label" } ],
             "definition" : [
               {
                 "identifier" : "definition",
@@ -6012,7 +6014,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "RapidStatusConfidenceLow", "en" : "Low rapid-status confidence" }
+          "labels" : { "IRI-based" : "RapidStatusConfidenceLow", "en" : "Low confidence" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceMedium",
@@ -6026,6 +6028,7 @@
                 "type" : "label"
               }
             ],
+            "altLabel" : [ { "identifier" : "altLabel", "language" : "en", "value" : "Medium rapid-status confidence", "type" : "label" } ],
             "definition" : [
               {
                 "identifier" : "definition",
@@ -6049,7 +6052,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "RapidStatusConfidenceMedium", "en" : "Medium rapid-status confidence" }
+          "labels" : { "IRI-based" : "RapidStatusConfidenceMedium", "en" : "Medium confidence" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusMetric",
@@ -6075,7 +6078,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "RapidStatusMetric" }
+          "labels" : { "IRI-based" : "RapidStatusMetric", "en" : "Rapid status metric" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusScoreMetric",
@@ -6137,7 +6140,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "RapidStatusScoreMetric" }
+          "labels" : { "IRI-based" : "RapidStatusScoreMetric", "en" : "Rapid status score metric" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#ReachCoverage",
@@ -6156,7 +6159,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 3 maximum" },
-          "labels" : { "IRI-based" : "ReachCoverage" }
+          "labels" : { "IRI-based" : "ReachCoverage", "en" : "Reach Coverage" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RecruitStageContext",
@@ -6171,7 +6174,7 @@
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContext", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "RecruitStageContext" }
+          "labels" : { "IRI-based" : "RecruitStageContext", "en" : "Recruit stage context" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RedZone",
@@ -6223,7 +6226,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "RedZone" }
+          "labels" : { "IRI-based" : "RedZone", "en" : "Red zone" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#ReddCount",
@@ -6249,7 +6252,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/EnumerationMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Legacy methods: Redd Counts" },
-          "labels" : { "IRI-based" : "ReddCount" }
+          "labels" : { "IRI-based" : "ReddCount", "en" : "Redd Count" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#ReddExpansionAnalysis",
@@ -6273,7 +6276,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EstimateMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Requires validated spawners-per-redd factor and documentation of detectability assumptions." },
-          "labels" : { "IRI-based" : "ReddExpansionAnalysis" }
+          "labels" : { "IRI-based" : "ReddExpansionAnalysis", "en" : "Redd Expansion Analysis" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RelativeAbundanceMetricStatus",
@@ -6331,7 +6334,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "RelativeAbundanceMetricStatus" }
+          "labels" : { "IRI-based" : "RelativeAbundanceMetricStatus", "en" : "Relative abundance metric status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#ReturnYear",
@@ -6379,7 +6382,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "ReturnYear" }
+          "labels" : { "IRI-based" : "ReturnYear", "en" : "Return year" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#ReviewQA",
@@ -6398,7 +6401,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 2 maximum" },
-          "labels" : { "IRI-based" : "ReviewQA" }
+          "labels" : { "IRI-based" : "ReviewQA", "en" : "Review/QA" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RunCoverage",
@@ -6417,7 +6420,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 2 maximum" },
-          "labels" : { "IRI-based" : "RunCoverage" }
+          "labels" : { "IRI-based" : "RunCoverage", "en" : "Run Coverage" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#SalmonEnhancementHatcheriesTheme",
@@ -6436,7 +6439,7 @@
             ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DataModelProvenanceTheme", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "SalmonEnhancementHatcheriesTheme" }
+          "labels" : { "IRI-based" : "SalmonEnhancementHatcheriesTheme", "en" : "Salmon Enhancement and Hatcheries" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Species",
@@ -6472,7 +6475,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "Species" }
+          "labels" : { "IRI-based" : "Species", "en" : "Species" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#SpeciesAtRiskRecoveryTheme",
@@ -6491,7 +6494,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "SpeciesAtRiskRecoveryTheme" }
+          "labels" : { "IRI-based" : "SpeciesAtRiskRecoveryTheme", "en" : "Species at Risk and Recovery" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme",
@@ -6510,7 +6513,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "StockAssessmentTheme" }
+          "labels" : { "IRI-based" : "StockAssessmentTheme", "en" : "Stock Assessment" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Timing",
@@ -6529,7 +6532,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 3 maximum" },
-          "labels" : { "IRI-based" : "Timing" }
+          "labels" : { "IRI-based" : "Timing", "en" : "Timing" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#TotalAgeDimension",
@@ -6542,7 +6545,7 @@
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#AgeDimension", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "TotalAgeDimension" }
+          "labels" : { "IRI-based" : "TotalAgeDimension", "en" : "Total age dimension" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#TrapCount",
@@ -6568,7 +6571,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/EnumerationMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Legacy methods: Trap, Hatchery Passage Counting" },
-          "labels" : { "IRI-based" : "TrapCount" }
+          "labels" : { "IRI-based" : "TrapCount", "en" : "Trap Count" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#TrapEfficiency",
@@ -6587,7 +6590,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 3 maximum" },
-          "labels" : { "IRI-based" : "TrapEfficiency" }
+          "labels" : { "IRI-based" : "TrapEfficiency", "en" : "Trap Efficiency" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#TrapModelAnalysis",
@@ -6611,7 +6614,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EstimateMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Requires documented trap efficiency measurements and cross-section coverage factors." },
-          "labels" : { "IRI-based" : "TrapModelAnalysis" }
+          "labels" : { "IRI-based" : "TrapModelAnalysis", "en" : "Trap Model Analysis" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Type1",
@@ -6634,7 +6637,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EstimateType", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Type1" }
+          "labels" : { "IRI-based" : "Type1", "en" : "Type-1, True Abundance, high resolution" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Type2",
@@ -6657,7 +6660,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EstimateType", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Type2" }
+          "labels" : { "IRI-based" : "Type2", "en" : "Type-2, True Abundance, medium resolution" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Type3",
@@ -6680,7 +6683,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EstimateType", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Type3" }
+          "labels" : { "IRI-based" : "Type3", "en" : "Type-3, Relative Abundance, high resolution" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Type4",
@@ -6703,7 +6706,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EstimateType", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Type4" }
+          "labels" : { "IRI-based" : "Type4", "en" : "Type-4, Relative Abundance, medium resolution" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Type5",
@@ -6726,7 +6729,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EstimateType", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Type5" }
+          "labels" : { "IRI-based" : "Type5", "en" : "Type-5, Relative Abundance, low resolution" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Type6",
@@ -6750,7 +6753,7 @@
             "altLabel" : [ { "identifier" : "altLabel", "language" : "en", "value" : "Presence/Not Detected", "type" : "label" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#EstimateType", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "Type6" }
+          "labels" : { "IRI-based" : "Type6", "en" : "Type-6, Presence or Absence" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#UnrankedIndexQuality",
@@ -6792,7 +6795,7 @@
               { "identifier" : "source", "language" : "undefined", "value" : "https://waves-vagues.dfo-mpo.gc.ca/Library/40890041.pdf", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "UnrankedIndexQuality" }
+          "labels" : { "IRI-based" : "UnrankedIndexQuality", "en" : "Unranked index quality" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#UpperBenchmark",
@@ -6814,7 +6817,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "UpperBenchmark" }
+          "labels" : { "IRI-based" : "UpperBenchmark", "en" : "Upper benchmark" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Uptime",
@@ -6835,7 +6838,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 2 maximum" },
-          "labels" : { "IRI-based" : "Uptime" }
+          "labels" : { "IRI-based" : "Uptime", "en" : "Uptime" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#Visibility",
@@ -6854,7 +6857,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#DowngradeCriteria", "type" : "iri" } ]
           },
           "comment" : { "en" : "Limits to Type 3 maximum" },
-          "labels" : { "IRI-based" : "Visibility" }
+          "labels" : { "IRI-based" : "Visibility", "en" : "Visibility" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#VisualGroundCount",
@@ -6880,7 +6883,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/EnumerationMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Legacy methods: Stream Walk, Ground count, Bank Walk" },
-          "labels" : { "IRI-based" : "VisualGroundCount" }
+          "labels" : { "IRI-based" : "VisualGroundCount", "en" : "Visual Ground Count" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#VisualSnorkelCount",
@@ -6906,7 +6909,7 @@
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/EnumerationMethod", "type" : "iri" } ]
           },
           "comment" : { "en" : "Legacy methods: Snorkel, Snorkel Swim" },
-          "labels" : { "IRI-based" : "VisualSnorkelCount" }
+          "labels" : { "IRI-based" : "VisualSnorkelCount", "en" : "Visual Snorkel Count" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#WSPOutputVariable",
@@ -6931,7 +6934,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "WSPOutputVariable" }
+          "labels" : { "IRI-based" : "WSPOutputVariable", "en" : "WSP output variable" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#WSPRapidStatusAssessmentMethod",
@@ -6972,7 +6975,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "WSPRapidStatusAssessmentMethod" }
+          "labels" : { "IRI-based" : "WSPRapidStatusAssessmentMethod", "en" : "WSP rapid-status assessment method" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicy",
@@ -6997,7 +7000,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#PolicyFramework", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "WildSalmonPolicy" }
+          "labels" : { "IRI-based" : "WildSalmonPolicy", "en" : "Wild Salmon Policy" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme",
@@ -7016,7 +7019,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "WildSalmonPolicyTheme" }
+          "labels" : { "IRI-based" : "WildSalmonPolicyTheme", "en" : "Wild Salmon Policy" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#YearBasis",
@@ -7046,7 +7049,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "YearBasis" }
+          "labels" : { "IRI-based" : "YearBasis", "en" : "Year basis" }
         },
         {
           "iri" : "https://w3id.org/smn/CatchContext",
@@ -7066,7 +7069,7 @@
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContext", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "CatchContext" }
+          "labels" : { "IRI-based" : "CatchContext", "en" : "Catch context" }
         },
         {
           "iri" : "https://w3id.org/smn/HatcheryOrigin",
@@ -7116,7 +7119,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "HatcheryOrigin" }
+          "labels" : { "IRI-based" : "HatcheryOrigin", "en" : "Hatchery-origin" }
         },
         {
           "iri" : "https://w3id.org/smn/InRiverPhase",
@@ -7137,7 +7140,7 @@
             "altLabel" : [ { "identifier" : "altLabel", "language" : "en", "value" : "Freshwater phase", "type" : "label" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhase", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "InRiverPhase" }
+          "labels" : { "IRI-based" : "InRiverPhase", "en" : "In-river phase" }
         },
         {
           "iri" : "https://w3id.org/smn/LifePhase",
@@ -7156,7 +7159,7 @@
             ],
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "LifePhase" }
+          "labels" : { "IRI-based" : "LifePhase", "en" : "Life phase" }
         },
         {
           "iri" : "https://w3id.org/smn/MainstemPhase",
@@ -7176,7 +7179,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhase", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "MainstemPhase" }
+          "labels" : { "IRI-based" : "MainstemPhase", "en" : "Mainstem phase" }
         },
         {
           "iri" : "https://w3id.org/smn/MeasurementContext",
@@ -7204,7 +7207,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "MeasurementContext" }
+          "labels" : { "IRI-based" : "MeasurementContext", "en" : "Measurement context" }
         },
         {
           "iri" : "https://w3id.org/smn/NaturalOrigin",
@@ -7249,7 +7252,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/SalmonOrigin", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "NaturalOrigin" }
+          "labels" : { "IRI-based" : "NaturalOrigin", "en" : "Natural-origin" }
         },
         {
           "iri" : "https://w3id.org/smn/OceanPhase",
@@ -7270,7 +7273,7 @@
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhase", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "OceanPhase" }
+          "labels" : { "IRI-based" : "OceanPhase", "en" : "Ocean phase" }
         },
         {
           "iri" : "https://w3id.org/smn/RunContext",
@@ -7290,7 +7293,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContext", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "RunContext" }
+          "labels" : { "IRI-based" : "RunContext", "en" : "Run context" }
         },
         {
           "iri" : "https://w3id.org/smn/SalmonOrigin",
@@ -7317,7 +7320,7 @@
               }
             ]
           },
-          "labels" : { "IRI-based" : "SalmonOrigin" }
+          "labels" : { "IRI-based" : "SalmonOrigin", "en" : "Salmon origin" }
         },
         {
           "iri" : "https://w3id.org/smn/SpawnerStageContext",
@@ -7337,7 +7340,7 @@
             ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContext", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "SpawnerStageContext" }
+          "labels" : { "IRI-based" : "SpawnerStageContext", "en" : "Spawner stage context" }
         },
         {
           "iri" : "https://w3id.org/smn/SurvivalOrMortalityContext",
@@ -7357,7 +7360,7 @@
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/MeasurementContext", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "SurvivalOrMortalityContext" }
+          "labels" : { "IRI-based" : "SurvivalOrMortalityContext", "en" : "Survival or mortality context" }
         },
         {
           "iri" : "https://w3id.org/smn/TerminalPhase",
@@ -7377,7 +7380,7 @@
             "theme" : [ { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" } ],
             "broader" : [ { "identifier" : "broader", "language" : "undefined", "value" : "https://w3id.org/smn/LifePhase", "type" : "iri" } ]
           },
-          "labels" : { "IRI-based" : "TerminalPhase" }
+          "labels" : { "IRI-based" : "TerminalPhase", "en" : "Terminal phase" }
         }
       ],
       "subClasses" : [ "141" ],
@@ -8260,7 +8263,7 @@
           }
         ]
       },
-      "label" : { "IRI-based" : "ConfidenceCategory" },
+      "label" : { "IRI-based" : "ConfidenceCategory", "en" : "Confidence category" },
       "individuals" : [
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceLow",
@@ -8274,6 +8277,7 @@
                 "type" : "label"
               }
             ],
+            "altLabel" : [ { "identifier" : "altLabel", "language" : "en", "value" : "Low rapid-status confidence", "type" : "label" } ],
             "definition" : [
               {
                 "identifier" : "definition",
@@ -8297,7 +8301,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "RapidStatusConfidenceLow", "en" : "Low rapid-status confidence" }
+          "labels" : { "IRI-based" : "RapidStatusConfidenceLow", "en" : "Low confidence" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceMedium",
@@ -8311,6 +8315,7 @@
                 "type" : "label"
               }
             ],
+            "altLabel" : [ { "identifier" : "altLabel", "language" : "en", "value" : "Medium rapid-status confidence", "type" : "label" } ],
             "definition" : [
               {
                 "identifier" : "definition",
@@ -8334,7 +8339,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "RapidStatusConfidenceMedium", "en" : "Medium rapid-status confidence" }
+          "labels" : { "IRI-based" : "RapidStatusConfidenceMedium", "en" : "Medium confidence" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RapidStatusConfidenceHigh",
@@ -8348,6 +8353,7 @@
                 "type" : "label"
               }
             ],
+            "altLabel" : [ { "identifier" : "altLabel", "language" : "en", "value" : "High rapid-status confidence", "type" : "label" } ],
             "definition" : [
               {
                 "identifier" : "definition",
@@ -8371,7 +8377,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#StockAssessmentTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "RapidStatusConfidenceHigh", "en" : "High rapid-status confidence" }
+          "labels" : { "IRI-based" : "RapidStatusConfidenceHigh", "en" : "High confidence" }
         }
       ],
       "id" : "236"
@@ -8664,7 +8670,7 @@
           { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
         ]
       },
-      "label" : { "IRI-based" : "IntegratedStatusOutcome" },
+      "label" : { "IRI-based" : "IntegratedStatusOutcome", "en" : "Integrated status outcome" },
       "individuals" : [
         {
           "iri" : "https://w3id.org/gcdfo/salmon#AmberZone",
@@ -8716,7 +8722,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "AmberZone" }
+          "labels" : { "IRI-based" : "AmberZone", "en" : "Amber zone" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#GreenZone",
@@ -8768,7 +8774,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "GreenZone" }
+          "labels" : { "IRI-based" : "GreenZone", "en" : "Green zone" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusAmberGreen",
@@ -8819,7 +8825,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusAmberGreen" }
+          "labels" : { "IRI-based" : "IntegratedStatusAmberGreen", "en" : "Amber/Green integrated status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusDataDeficient",
@@ -8866,7 +8872,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusDataDeficient" }
+          "labels" : { "IRI-based" : "IntegratedStatusDataDeficient", "en" : "Data deficient integrated status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusNotRed",
@@ -8905,7 +8911,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusNotRed" }
+          "labels" : { "IRI-based" : "IntegratedStatusNotRed", "en" : "Not-red integrated status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusRedAmber",
@@ -8956,7 +8962,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusRedAmber" }
+          "labels" : { "IRI-based" : "IntegratedStatusRedAmber", "en" : "Red/Amber integrated status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#IntegratedStatusUndetermined",
@@ -9004,7 +9010,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "IntegratedStatusUndetermined" }
+          "labels" : { "IRI-based" : "IntegratedStatusUndetermined", "en" : "Undetermined integrated status" }
         },
         {
           "iri" : "https://w3id.org/gcdfo/salmon#RedZone",
@@ -9056,7 +9062,7 @@
               { "identifier" : "theme", "language" : "undefined", "value" : "https://w3id.org/gcdfo/salmon#WildSalmonPolicyTheme", "type" : "iri" }
             ]
           },
-          "labels" : { "IRI-based" : "RedZone" }
+          "labels" : { "IRI-based" : "RedZone", "en" : "Red zone" }
         }
       ],
       "id" : "339"
@@ -9934,8 +9940,8 @@
       "attributes" : [ "external", "object" ],
       "id" : "232"
     },
-    { "domain" : "142", "range" : "222", "id" : "234", "label" : { "IRI-based" : "14", "undefined" : "is a" } },
-    { "domain" : "142", "range" : "236", "id" : "235", "label" : { "IRI-based" : "16", "undefined" : "is a" } },
+    { "domain" : "142", "range" : "222", "id" : "234", "label" : { "IRI-based" : "15", "undefined" : "is a" } },
+    { "domain" : "142", "range" : "236", "id" : "235", "label" : { "IRI-based" : "13", "undefined" : "is a" } },
     {
       "iri" : "https://w3id.org/gcdfo/salmon#hasAssessmentReferencePoint",
       "inverse" : "238",
@@ -9989,7 +9995,7 @@
       "id" : "238",
       "inverse" : "237"
     },
-    { "domain" : "142", "range" : "24", "id" : "240", "label" : { "IRI-based" : "15", "undefined" : "is a" } },
+    { "domain" : "142", "range" : "24", "id" : "240", "label" : { "IRI-based" : "14", "undefined" : "is a" } },
     {
       "iri" : "https://w3id.org/gcdfo/salmon#hasObservedVariable",
       "baseIri" : "https://w3id.org/gcdfo/salmon",
@@ -10260,7 +10266,7 @@
     { "range" : "43", "domain" : "1", "attributes" : [ "anonymous", "object" ], "id" : "334" },
     { "range" : "43", "domain" : "248", "attributes" : [ "anonymous", "object" ], "id" : "335" },
     { "range" : "43", "domain" : "116", "attributes" : [ "anonymous", "object" ], "id" : "336" },
-    { "domain" : "142", "range" : "339", "id" : "342", "label" : { "IRI-based" : "13", "undefined" : "is a" } },
+    { "domain" : "142", "range" : "339", "id" : "342", "label" : { "IRI-based" : "16", "undefined" : "is a" } },
     { "range" : "99", "domain" : "340", "attributes" : [ "anonymous", "object" ], "id" : "343" },
     { "range" : "99", "domain" : "341", "attributes" : [ "anonymous", "object" ], "id" : "344" }
   ]

--- a/ontology/dfo-salmon.ttl
+++ b/ontology/dfo-salmon.ttl
@@ -72,6 +72,7 @@ gcdfo:ThemeScheme a skos:ConceptScheme ;
 
 gcdfo:StockAssessmentTheme a skos:Concept ;
   skos:prefLabel "Stock Assessment"@en ;
+  rdfs:label "Stock Assessment"@en ;
   skos:inScheme gcdfo:ThemeScheme ;
   skos:definition "Stock assessment models, benchmarks, status determinations, and performance metrics for salmon units."@en ;
   gcdfo:theme gcdfo:DataModelProvenanceTheme ;
@@ -79,6 +80,7 @@ gcdfo:StockAssessmentTheme a skos:Concept ;
 
 gcdfo:MonitoringFieldWorkTheme a skos:Concept ;
   skos:prefLabel "Monitoring and Field Work"@en ;
+  rdfs:label "Monitoring and Field Work"@en ;
   skos:inScheme gcdfo:ThemeScheme ;
   skos:definition "Field observations, sampling protocols, survey events, gear, and measurement methods used to collect salmon data."@en ;
   gcdfo:theme gcdfo:DataModelProvenanceTheme ;
@@ -86,6 +88,7 @@ gcdfo:MonitoringFieldWorkTheme a skos:Concept ;
 
 gcdfo:GeneticsStockCompositionTheme a skos:Concept ;
   skos:prefLabel "Genetics and Stock Composition"@en ;
+  rdfs:label "Genetics and Stock Composition"@en ;
   skos:inScheme gcdfo:ThemeScheme ;
   skos:definition "Genetic markers, assays, and analyses used to infer stock composition, parentage, and population structure."@en ;
   gcdfo:theme gcdfo:DataModelProvenanceTheme ;
@@ -93,6 +96,7 @@ gcdfo:GeneticsStockCompositionTheme a skos:Concept ;
 
 gcdfo:WildSalmonPolicyTheme a skos:Concept ;
   skos:prefLabel "Wild Salmon Policy"@en ;
+  rdfs:label "Wild Salmon Policy"@en ;
   skos:inScheme gcdfo:ThemeScheme ;
   skos:definition "Conservation Unit based stock assessment methods, metrics, and metadata"@en ;
   gcdfo:theme gcdfo:DataModelProvenanceTheme ;
@@ -100,6 +104,7 @@ gcdfo:WildSalmonPolicyTheme a skos:Concept ;
 
 gcdfo:FisheriesManagementTheme a skos:Concept ;
   skos:prefLabel "Fisheries Management"@en ;
+  rdfs:label "Fisheries Management"@en ;
   skos:inScheme gcdfo:ThemeScheme ;
   skos:definition "Fishery openings, harvest control rules, catch/effort measures, and exploitation monitoring for salmon fisheries."@en ;
   gcdfo:theme gcdfo:DataModelProvenanceTheme ;
@@ -107,6 +112,7 @@ gcdfo:FisheriesManagementTheme a skos:Concept ;
 
 gcdfo:SpeciesAtRiskRecoveryTheme a skos:Concept ;
   skos:prefLabel "Species at Risk and Recovery"@en ;
+  rdfs:label "Species at Risk and Recovery"@en ;
   skos:inScheme gcdfo:ThemeScheme ;
   skos:definition "COSEWIC/SARA recovery planning, critical habitat, threats, and status assessments for species of conservation concern."@en ;
   gcdfo:theme gcdfo:DataModelProvenanceTheme ;
@@ -114,6 +120,7 @@ gcdfo:SpeciesAtRiskRecoveryTheme a skos:Concept ;
 
 gcdfo:SalmonEnhancementHatcheriesTheme a skos:Concept ;
   skos:prefLabel "Salmon Enhancement and Hatcheries"@en ;
+  rdfs:label "Salmon Enhancement and Hatcheries"@en ;
   skos:inScheme gcdfo:ThemeScheme ;
   skos:definition "Hatchery production, broodstock management, releases, and enhancement program practices for salmon."@en ;
   gcdfo:theme gcdfo:DataModelProvenanceTheme ;
@@ -121,6 +128,7 @@ gcdfo:SalmonEnhancementHatcheriesTheme a skos:Concept ;
 
 gcdfo:HabitatEcosystemClimateTheme a skos:Concept ;
   skos:prefLabel "Habitat, Ecosystem, and Climate Pressures"@en ;
+  rdfs:label "Habitat, Ecosystem, and Climate Pressures"@en ;
   skos:inScheme gcdfo:ThemeScheme ;
   skos:definition "Habitat attributes, ecosystem conditions, and climate or environmental stressors affecting salmon."@en ;
   gcdfo:theme gcdfo:DataModelProvenanceTheme ;
@@ -128,6 +136,7 @@ gcdfo:HabitatEcosystemClimateTheme a skos:Concept ;
 
 gcdfo:PolicyGovernanceTheme a skos:Concept ;
   skos:prefLabel "Policy, Governance, and Organizational Structure"@en ;
+  rdfs:label "Policy, Governance, and Organizational Structure"@en ;
   skos:inScheme gcdfo:ThemeScheme ;
   skos:definition "DFO policy frameworks, governance, regulations, and organizational structure relevant to salmon management."@en ;
   gcdfo:theme gcdfo:DataModelProvenanceTheme ;
@@ -135,6 +144,7 @@ gcdfo:PolicyGovernanceTheme a skos:Concept ;
 
 gcdfo:DataModelProvenanceTheme a skos:Concept ;
   skos:prefLabel "Data, Models, and Provenance"@en ;
+  rdfs:label "Data, Models, and Provenance"@en ;
   skos:inScheme gcdfo:ThemeScheme ;
   skos:definition "Data models, analytical workflows, provenance, quality dimensions, and metadata supporting salmon science."@en ;
   gcdfo:theme gcdfo:DataModelProvenanceTheme ;
@@ -580,6 +590,7 @@ smn:LifePhaseScheme a skos:ConceptScheme ;
 
 gcdfo:AgeNotation a skos:Concept ;
   skos:prefLabel "Age notation"@en ;
+  rdfs:label "Age notation"@en ;
   skos:definition "A notation system used to encode salmon age values in stock assessment data."@en ;
   skos:inScheme :AgeNotationScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:DataModelProvenanceTheme ;
@@ -587,6 +598,7 @@ gcdfo:AgeNotation a skos:Concept ;
 
 gcdfo:GilbertRichAgeNotation a skos:Concept ;
   skos:prefLabel "Gilbert-Rich age notation"@en ;
+  rdfs:label "Gilbert-Rich age notation"@en ;
   skos:altLabel "GR age notation"@en ;
   skos:definition "Salmon age notation where total age is annotated with freshwater years as a subscript-like suffix (for example, 4_2 for total age 4 with 2 freshwater years)."@en ;
   skos:notation "Gilbert-Rich"^^xsd:string ;
@@ -598,6 +610,7 @@ gcdfo:GilbertRichAgeNotation a skos:Concept ;
 
 gcdfo:EuropeanAgeNotation a skos:Concept ;
   skos:prefLabel "European age notation"@en ;
+  rdfs:label "European age notation"@en ;
   skos:definition "Salmon age notation that records freshwater years followed by ocean years (for example, 1.2)."@en ;
   skos:notation "European"^^xsd:string ;
   skos:inScheme :AgeNotationScheme ;
@@ -608,6 +621,7 @@ gcdfo:EuropeanAgeNotation a skos:Concept ;
 
 gcdfo:AgeBasis a skos:Concept ;
   skos:prefLabel "Age basis"@en ;
+  rdfs:label "Age basis"@en ;
   skos:definition "The reference event or life-history point that an age value is measured against."@en ;
   skos:inScheme :AgeBasisScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:DataModelProvenanceTheme ;
@@ -615,6 +629,7 @@ gcdfo:AgeBasis a skos:Concept ;
 
 gcdfo:AgeAtReturnBasis a skos:Concept ;
   skos:prefLabel "Age at return basis"@en ;
+  rdfs:label "Age at return basis"@en ;
   skos:definition "Age measured at return migration (adult return timing)."@en ;
   skos:inScheme :AgeBasisScheme ;
   skos:broader gcdfo:AgeBasis ;
@@ -623,6 +638,7 @@ gcdfo:AgeAtReturnBasis a skos:Concept ;
 
 gcdfo:AgeAtMaturityBasis a skos:Concept ;
   skos:prefLabel "Age at maturity basis"@en ;
+  rdfs:label "Age at maturity basis"@en ;
   skos:definition "Age measured at maturity."@en ;
   skos:inScheme :AgeBasisScheme ;
   skos:broader gcdfo:AgeBasis ;
@@ -631,6 +647,7 @@ gcdfo:AgeAtMaturityBasis a skos:Concept ;
 
 gcdfo:AgeAtSamplingBasis a skos:Concept ;
   skos:prefLabel "Age at sampling basis"@en ;
+  rdfs:label "Age at sampling basis"@en ;
   skos:definition "Age measured at the time of sampling or observation."@en ;
   skos:inScheme :AgeBasisScheme ;
   skos:broader gcdfo:AgeBasis ;
@@ -639,6 +656,7 @@ gcdfo:AgeAtSamplingBasis a skos:Concept ;
 
 gcdfo:AgeDimension a skos:Concept ;
   skos:prefLabel "Age dimension"@en ;
+  rdfs:label "Age dimension"@en ;
   skos:definition "The age component represented by a value (total age, freshwater years, or ocean years)."@en ;
   skos:inScheme :AgeDimensionScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
@@ -646,6 +664,7 @@ gcdfo:AgeDimension a skos:Concept ;
 
 gcdfo:TotalAgeDimension a skos:Concept ;
   skos:prefLabel "Total age dimension"@en ;
+  rdfs:label "Total age dimension"@en ;
   skos:definition "Age value represents total age in years."@en ;
   skos:inScheme :AgeDimensionScheme ;
   skos:broader gcdfo:AgeDimension ;
@@ -654,6 +673,7 @@ gcdfo:TotalAgeDimension a skos:Concept ;
 
 gcdfo:FreshwaterAgeDimension a skos:Concept ;
   skos:prefLabel "Freshwater age dimension"@en ;
+  rdfs:label "Freshwater age dimension"@en ;
   skos:definition "Age value represents years spent in freshwater."@en ;
   skos:inScheme :AgeDimensionScheme ;
   skos:broader gcdfo:AgeDimension ;
@@ -662,6 +682,7 @@ gcdfo:FreshwaterAgeDimension a skos:Concept ;
 
 gcdfo:OceanAgeDimension a skos:Concept ;
   skos:prefLabel "Ocean age dimension"@en ;
+  rdfs:label "Ocean age dimension"@en ;
   skos:altLabel "Marine age dimension"@en ;
   skos:definition "Age value represents years spent in the marine environment."@en ;
   skos:inScheme :AgeDimensionScheme ;
@@ -671,6 +692,7 @@ gcdfo:OceanAgeDimension a skos:Concept ;
 
 gcdfo:AgeClassValue a skos:Concept ;
   skos:prefLabel "Age class value"@en ;
+  rdfs:label "Age class value"@en ;
   skos:definition "An integer-like age class value used as a compositional constraint in salmon measurements."@en ;
   skos:inScheme :AgeClassValueScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
@@ -678,6 +700,7 @@ gcdfo:AgeClassValue a skos:Concept ;
 
 gcdfo:Age1YearClass a skos:Concept ;
   skos:prefLabel "Age 1 year class"@en ;
+  rdfs:label "Age 1 year class"@en ;
   skos:notation "1"^^xsd:integer ;
   skos:definition "Age class value 1 year."@en ;
   skos:inScheme :AgeClassValueScheme ;
@@ -687,6 +710,7 @@ gcdfo:Age1YearClass a skos:Concept ;
 
 gcdfo:Age2YearClass a skos:Concept ;
   skos:prefLabel "Age 2 year class"@en ;
+  rdfs:label "Age 2 year class"@en ;
   skos:notation "2"^^xsd:integer ;
   skos:definition "Age class value 2 years."@en ;
   skos:inScheme :AgeClassValueScheme ;
@@ -696,6 +720,7 @@ gcdfo:Age2YearClass a skos:Concept ;
 
 gcdfo:Age3YearClass a skos:Concept ;
   skos:prefLabel "Age 3 year class"@en ;
+  rdfs:label "Age 3 year class"@en ;
   skos:notation "3"^^xsd:integer ;
   skos:definition "Age class value 3 years."@en ;
   skos:inScheme :AgeClassValueScheme ;
@@ -705,6 +730,7 @@ gcdfo:Age3YearClass a skos:Concept ;
 
 gcdfo:Age4YearClass a skos:Concept ;
   skos:prefLabel "Age 4 year class"@en ;
+  rdfs:label "Age 4 year class"@en ;
   skos:notation "4"^^xsd:integer ;
   skos:definition "Age class value 4 years."@en ;
   skos:inScheme :AgeClassValueScheme ;
@@ -714,6 +740,7 @@ gcdfo:Age4YearClass a skos:Concept ;
 
 gcdfo:Age5YearClass a skos:Concept ;
   skos:prefLabel "Age 5 year class"@en ;
+  rdfs:label "Age 5 year class"@en ;
   skos:notation "5"^^xsd:integer ;
   skos:definition "Age class value 5 years."@en ;
   skos:inScheme :AgeClassValueScheme ;
@@ -723,6 +750,7 @@ gcdfo:Age5YearClass a skos:Concept ;
 
 gcdfo:Age6YearClass a skos:Concept ;
   skos:prefLabel "Age 6 year class"@en ;
+  rdfs:label "Age 6 year class"@en ;
   skos:notation "6"^^xsd:integer ;
   skos:definition "Age class value 6 years."@en ;
   skos:inScheme :AgeClassValueScheme ;
@@ -732,6 +760,7 @@ gcdfo:Age6YearClass a skos:Concept ;
 
 gcdfo:Age7YearClass a skos:Concept ;
   skos:prefLabel "Age 7 year class"@en ;
+  rdfs:label "Age 7 year class"@en ;
   skos:notation "7"^^xsd:integer ;
   skos:definition "Age class value 7 years."@en ;
   skos:inScheme :AgeClassValueScheme ;
@@ -741,6 +770,7 @@ gcdfo:Age7YearClass a skos:Concept ;
 
 smn:MeasurementContext a skos:Concept ;
   skos:prefLabel "Measurement context"@en ;
+  rdfs:label "Measurement context"@en ;
   skos:definition "A context qualifier used to disambiguate the interpretation of a measurement column."@en ;
   skos:inScheme smn:MeasurementContextScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:DataModelProvenanceTheme ;
@@ -748,6 +778,7 @@ smn:MeasurementContext a skos:Concept ;
 
 smn:CatchContext a skos:Concept ;
   skos:prefLabel "Catch context"@en ;
+  rdfs:label "Catch context"@en ;
   skos:definition "Measurement context indicating values refer to fishery catch."@en ;
   skos:inScheme smn:MeasurementContextScheme ;
   skos:broader smn:MeasurementContext ;
@@ -756,6 +787,7 @@ smn:CatchContext a skos:Concept ;
 
 smn:RunContext a skos:Concept ;
   skos:prefLabel "Run context"@en ;
+  rdfs:label "Run context"@en ;
   skos:definition "Measurement context indicating values refer to run size or returning run composition."@en ;
   skos:inScheme smn:MeasurementContextScheme ;
   skos:broader smn:MeasurementContext ;
@@ -764,6 +796,7 @@ smn:RunContext a skos:Concept ;
 
 smn:SpawnerStageContext a skos:Concept ;
   skos:prefLabel "Spawner stage context"@en ;
+  rdfs:label "Spawner stage context"@en ;
   skos:definition "Measurement context indicating values refer to spawners or spawning-stage fish."@en ;
   skos:inScheme smn:MeasurementContextScheme ;
   skos:broader smn:MeasurementContext ;
@@ -772,6 +805,7 @@ smn:SpawnerStageContext a skos:Concept ;
 
 gcdfo:RecruitStageContext a skos:Concept ;
   skos:prefLabel "Recruit stage context"@en ;
+  rdfs:label "Recruit stage context"@en ;
   skos:definition "Measurement context indicating values refer to recruits."@en ;
   skos:inScheme smn:MeasurementContextScheme ;
   skos:broader smn:MeasurementContext ;
@@ -780,6 +814,7 @@ gcdfo:RecruitStageContext a skos:Concept ;
 
 smn:SurvivalOrMortalityContext a skos:Concept ;
   skos:prefLabel "Survival or mortality context"@en ;
+  rdfs:label "Survival or mortality context"@en ;
   skos:definition "Measurement context indicating values represent survival, mortality, or related rates."@en ;
   skos:inScheme smn:MeasurementContextScheme ;
   skos:broader smn:MeasurementContext ;
@@ -788,6 +823,7 @@ smn:SurvivalOrMortalityContext a skos:Concept ;
 
 gcdfo:ManagementReferenceContext a skos:Concept ;
   skos:prefLabel "Management reference context"@en ;
+  rdfs:label "Management reference context"@en ;
   skos:definition "Measurement context indicating values are management benchmarks or reference-oriented metrics."@en ;
   skos:inScheme smn:MeasurementContextScheme ;
   skos:broader smn:MeasurementContext ;
@@ -796,6 +832,7 @@ gcdfo:ManagementReferenceContext a skos:Concept ;
 
 gcdfo:DataQualityRatingContext a skos:Concept ;
   skos:prefLabel "Data quality rating context"@en ;
+  rdfs:label "Data quality rating context"@en ;
   skos:definition "Measurement context indicating categorical or ordinal quality ratings."@en ;
   skos:inScheme smn:MeasurementContextScheme ;
   skos:broader smn:MeasurementContext ;
@@ -804,6 +841,7 @@ gcdfo:DataQualityRatingContext a skos:Concept ;
 
 smn:SalmonOrigin a skos:Concept ;
   skos:prefLabel "Salmon origin"@en ;
+  rdfs:label "Salmon origin"@en ;
   skos:definition "Origin category describing whether salmon are naturally produced, hatchery produced, or mixed-origin."@en ;
   skos:inScheme smn:SalmonOriginScheme ;
   gcdfo:theme gcdfo:SalmonEnhancementHatcheriesTheme, gcdfo:StockAssessmentTheme ;
@@ -811,6 +849,7 @@ smn:SalmonOrigin a skos:Concept ;
 
 smn:HatcheryOrigin a skos:Concept ;
   skos:prefLabel "Hatchery-origin"@en ;
+  rdfs:label "Hatchery-origin"@en ;
   skos:definition "Individuals that were born or reared in a hatchery facility."@en ;
   skos:inScheme smn:SalmonOriginScheme ;
   skos:broader smn:SalmonOrigin ;
@@ -821,6 +860,7 @@ smn:HatcheryOrigin a skos:Concept ;
 
 smn:NaturalOrigin a skos:Concept ;
   skos:prefLabel "Natural-origin"@en ;
+  rdfs:label "Natural-origin"@en ;
   skos:definition "Individuals that are born and reared in the wild (natural environment)."@en ;
   skos:inScheme smn:SalmonOriginScheme ;
   skos:broader smn:SalmonOrigin ;
@@ -831,6 +871,7 @@ smn:NaturalOrigin a skos:Concept ;
 
 smn:LifePhase a skos:Concept ;
   skos:prefLabel "Life phase"@en ;
+  rdfs:label "Life phase"@en ;
   skos:definition "A phase or segment used to stratify salmon measurements by where or when they apply (e.g., ocean phase, terminal phase)."@en ;
   skos:inScheme smn:LifePhaseScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
@@ -838,6 +879,7 @@ smn:LifePhase a skos:Concept ;
 
 smn:OceanPhase a skos:Concept ;
   skos:prefLabel "Ocean phase"@en ;
+  rdfs:label "Ocean phase"@en ;
   skos:altLabel "Marine phase"@en ;
   skos:definition "Phase of the salmon life cycle or assessment period occurring in the marine environment."@en ;
   skos:inScheme smn:LifePhaseScheme ;
@@ -847,6 +889,7 @@ smn:OceanPhase a skos:Concept ;
 
 smn:TerminalPhase a skos:Concept ;
   skos:prefLabel "Terminal phase"@en ;
+  rdfs:label "Terminal phase"@en ;
   skos:definition "Phase occurring in terminal areas near river mouths or spawning areas (often including terminal fisheries and local migration to spawning sites)."@en ;
   skos:inScheme smn:LifePhaseScheme ;
   skos:broader smn:LifePhase ;
@@ -855,6 +898,7 @@ smn:TerminalPhase a skos:Concept ;
 
 smn:MainstemPhase a skos:Concept ;
   skos:prefLabel "Mainstem phase"@en ;
+  rdfs:label "Mainstem phase"@en ;
   skos:definition "Freshwater mainstem migration phase in a river system (often corresponding to mainstem in-river fisheries or monitoring segments)."@en ;
   skos:inScheme smn:LifePhaseScheme ;
   skos:broader smn:LifePhase ;
@@ -863,6 +907,7 @@ smn:MainstemPhase a skos:Concept ;
 
 smn:InRiverPhase a skos:Concept ;
   skos:prefLabel "In-river phase"@en ;
+  rdfs:label "In-river phase"@en ;
   skos:altLabel "Freshwater phase"@en ;
   skos:definition "Freshwater in-river phase (migration and/or residence) outside the marine environment."@en ;
   skos:inScheme smn:LifePhaseScheme ;
@@ -872,6 +917,7 @@ smn:InRiverPhase a skos:Concept ;
 
 gcdfo:LowerBenchmark a skos:Concept ;
   skos:prefLabel "Lower benchmark"@en ;
+  rdfs:label "Lower benchmark"@en ;
   skos:definition "A lower-threshold benchmark value, typically delineating the boundary between Red and Amber status zones."@en ;
   skos:inScheme :BenchmarkLevelScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:WildSalmonPolicyTheme ;
@@ -879,6 +925,7 @@ gcdfo:LowerBenchmark a skos:Concept ;
 
 gcdfo:UpperBenchmark a skos:Concept ;
   skos:prefLabel "Upper benchmark"@en ;
+  rdfs:label "Upper benchmark"@en ;
   skos:definition "An upper-threshold benchmark value, typically delineating the boundary between Amber and Green status zones."@en ;
   skos:inScheme :BenchmarkLevelScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:WildSalmonPolicyTheme ;
@@ -886,6 +933,7 @@ gcdfo:UpperBenchmark a skos:Concept ;
 
 gcdfo:PolicyFramework a skos:Concept ;
   skos:prefLabel "Policy framework"@en ;
+  rdfs:label "Policy framework"@en ;
   skos:definition "A policy, legal, or governance framework that defines how salmon status metrics, benchmarks, or reference points are set and interpreted."@en ;
   skos:inScheme :PolicyFrameworkScheme ;
   gcdfo:theme gcdfo:PolicyGovernanceTheme, gcdfo:StockAssessmentTheme, gcdfo:WildSalmonPolicyTheme ;
@@ -893,6 +941,7 @@ gcdfo:PolicyFramework a skos:Concept ;
 
 gcdfo:WildSalmonPolicy a skos:Concept ;
   skos:prefLabel "Wild Salmon Policy"@en ;
+  rdfs:label "Wild Salmon Policy"@en ;
   skos:altLabel "WSP"@en ;
   skos:definition "Canada's Wild Salmon Policy framework for conserving and managing wild Pacific salmon, including integrated status assessments and biological benchmarks for Conservation Units."@en ;
   skos:inScheme :PolicyFrameworkScheme ;
@@ -902,6 +951,7 @@ gcdfo:WildSalmonPolicy a skos:Concept ;
 
 gcdfo:PrecautionaryApproach a skos:Concept ;
   skos:prefLabel "Precautionary Approach"@en ;
+  rdfs:label "Precautionary Approach"@en ;
   skos:altLabel "PA"@en ;
   skos:definition "DFO policy framework for applying precaution in fisheries decision-making, including use of reference points and stock status zones."@en ;
   skos:inScheme :PolicyFrameworkScheme ;
@@ -911,6 +961,7 @@ gcdfo:PrecautionaryApproach a skos:Concept ;
 
 gcdfo:FishStockProvisions a skos:Concept ;
   skos:prefLabel "Fish Stocks Provisions"@en ;
+  rdfs:label "Fish Stocks Provisions"@en ;
   skos:altLabel "FSP"@en ;
   skos:definition "Legal provisions in Canada's Fisheries Act and regulations related to maintaining and rebuilding fish stocks, including obligations triggered when reference points are breached."@en ;
   skos:inScheme :PolicyFrameworkScheme ;
@@ -924,6 +975,7 @@ gcdfo:FishStockProvisions a skos:Concept ;
 
 smn:EnumerationMethod a skos:Concept ;
   skos:prefLabel "Enumeration Method"@en ;
+  rdfs:label "Enumeration Method"@en ;
   skos:definition "A method used to enumerate or count salmon in the field"@en ;
   skos:scopeNote "DFO profile note: this ontology uses the shared `smn:EnumerationMethod` concept directly and constrains local narrower methods beneath it."@en ;
   skos:inScheme :EnumerationMethodScheme ;
@@ -932,6 +984,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :FixedSiteCensusManual a skos:Concept ;
   skos:prefLabel "Fixed Site Census (Manual)"@en ;
+  rdfs:label "Fixed Site Census (Manual)"@en ;
   skos:definition "Salmon are guided through a controlled opening in a fence/weir where trained observers visually tally each passage event on a continuous or daily schedule. Counting chambers/windows and SIL/SEN daily logs document coverage; bypass routes are monitored and closed where possible."@en ;
   skos:inScheme :EnumerationMethodScheme ;
   skos:broader smn:EnumerationMethod ;
@@ -941,6 +994,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :FixedSiteCensusElectronic a skos:Concept ;
   skos:prefLabel "Fixed Site Census (Electronic)"@en ;
+  rdfs:label "Fixed Site Census (Electronic)"@en ;
   skos:definition "Automated counting at a constrained opening using electronic/optical counters, resistivity counters, or video/camera systems. QA review of automated events, cross-section coverage, and uptime/coverage are documented."@en ;
   skos:inScheme :EnumerationMethodScheme ;
   skos:broader smn:EnumerationMethod ;
@@ -950,6 +1004,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :VisualGroundCount a skos:Concept ;
   skos:prefLabel "Visual Ground Count"@en ;
+  rdfs:label "Visual Ground Count"@en ;
   skos:definition "Visual surveys conducted by stream/bank walk with documented visit schedule, reach coverage, timing, and visibility conditions."@en ;
   skos:inScheme :EnumerationMethodScheme ;
   skos:broader smn:EnumerationMethod ;
@@ -960,6 +1015,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :VisualSnorkelCount a skos:Concept ;
   skos:prefLabel "Visual Snorkel Count"@en ;
+  rdfs:label "Visual Snorkel Count"@en ;
   skos:definition "Two or more trained snorkelers conduct standardized passes within defined segments, tallying live/dead by species. Field forms capture visibility class, segment boundaries, and repeat-visit schedule; counts are aggregated across observers/passes."@en ;
   skos:inScheme :EnumerationMethodScheme ;
   skos:broader smn:EnumerationMethod ;
@@ -969,6 +1025,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :AerialSurveyCount a skos:Concept ;
   skos:prefLabel "Aerial Survey Count"@en ;
+  rdfs:label "Aerial Survey Count"@en ;
   skos:definition "Overflights (helicopter, fixed wing, or drone) with documented flight lines, coverage, visibility, and sensor settings. Imagery may be reviewed post-flight."@en ;
   skos:inScheme :EnumerationMethodScheme ;
   skos:broader smn:EnumerationMethod ;
@@ -978,6 +1035,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :HydroacousticSonarCount a skos:Concept ;
   skos:prefLabel "Hydroacoustic Sonar Count"@en ;
+  rdfs:label "Hydroacoustic Sonar Count"@en ;
   skos:definition "Sonar detections (ARIS, DIDSON, or other hydroacoustic systems) with documented coverage, visibility/noise conditions, and uptime. Raw detections require processing through a modelling/classification pipeline."@en ;
   skos:inScheme :EnumerationMethodScheme ;
   skos:broader smn:EnumerationMethod ;
@@ -987,6 +1045,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :TrapCount a skos:Concept ;
   skos:prefLabel "Trap Count"@en ;
+  rdfs:label "Trap Count"@en ;
   skos:definition "Trap-based counts from non-spanning traps with documented emptying schedule, efficiency measurements, and coverage information."@en ;
   skos:inScheme :EnumerationMethodScheme ;
   skos:broader smn:EnumerationMethod ;
@@ -996,6 +1055,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :ReddCount a skos:Concept ;
   skos:prefLabel "Redd Count"@en ;
+  rdfs:label "Redd Count"@en ;
   skos:definition "Redd counts with documentation of detectability, timing, and reach coverage. Conversion to spawner estimates requires spawners-per-redd factors handled in analysis."@en ;
   skos:inScheme :EnumerationMethodScheme ;
   skos:broader smn:EnumerationMethod ;
@@ -1005,6 +1065,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :ElectrofishingCount a skos:Concept ;
   skos:prefLabel "Electrofishing Count"@en ;
+  rdfs:label "Electrofishing Count"@en ;
   skos:definition "Effort-standardized electrofishing passes used to generate catch-per-unit-effort (CPUE) indices."@en ;
   skos:inScheme :EnumerationMethodScheme ;
   skos:broader smn:EnumerationMethod ;
@@ -1014,6 +1075,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :MarkRecaptureFieldProgram a skos:Concept ;
   skos:prefLabel "Mark-Recapture Field Program"@en ;
+  rdfs:label "Mark-Recapture Field Program"@en ;
   skos:definition "Field program involving marking and subsequent recapture/recovery of tagged fish with documented assumptions and recovery coverage."@en ;
   skos:inScheme :EnumerationMethodScheme ;
   skos:broader smn:EnumerationMethod ;
@@ -1027,6 +1089,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :FixedStationTally a skos:Concept ;
   skos:prefLabel "Fixed‑Station Tally"@en ;
+  rdfs:label "Fixed‑Station Tally"@en ;
   skos:definition "Seasonal total = roll‑up of daily/continuous counts from a fixed (non‑sonar) station; simple arithmetic with documented coverage."@en ;
   skos:inScheme :EstimateMethodScheme ;
   skos:broader :EstimateMethod ;
@@ -1035,6 +1098,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :AreaUnderTheCurve a skos:Concept ;
   skos:prefLabel "Area Under the Curve"@en ;
+  rdfs:label "Area Under the Curve"@en ;
   skos:altLabel "AUC"@en ;
   skos:definition "Integrates serial counts over time using a survey-life parameter; may apply observer efficiency."@en ;
   skos:inScheme :EstimateMethodScheme ;
@@ -1044,6 +1108,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :PeakCountAnalysis a skos:Concept ;
   skos:prefLabel "Peak Count Analysis"@en ;
+  rdfs:label "Peak Count Analysis"@en ;
   skos:definition "Uses the peak survey (live ± dead variants) as the season estimate/index."@en ;
   skos:inScheme :EstimateMethodScheme ;
   skos:broader :EstimateMethod ;
@@ -1053,6 +1118,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :HydroacousticModelling a skos:Concept ;
   skos:prefLabel "Hydroacoustic Modelling"@en ;
+  rdfs:label "Hydroacoustic Modelling"@en ;
   skos:definition "Model pipeline converts sonar detections to passage totals; sets range/angle/blind zones; species/size attribution rules documented."@en ;
   skos:inScheme :EstimateMethodScheme ;
   skos:broader :EstimateMethod ;
@@ -1062,6 +1128,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :ExpansionMathematicalOperations a skos:Concept ;
   skos:prefLabel "Expansion/Mathematical Operations"@en ;
+  rdfs:label "Expansion/Mathematical Operations"@en ;
   skos:definition "Applies expansion factors or arithmetic transforms to a base count/index."@en ;
   skos:inScheme :EstimateMethodScheme ;
   skos:broader :EstimateMethod ;
@@ -1071,6 +1138,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :CalibratedTimeSeries a skos:Concept ;
   skos:prefLabel "Calibrated Time Series"@en ;
+  rdfs:label "Calibrated Time Series"@en ;
   skos:definition "Regression/state-space model calibrated to a Type-1/2 series converts a lower-precision index to abundance."@en ;
   skos:inScheme :EstimateMethodScheme ;
   skos:broader :EstimateMethod ;
@@ -1080,6 +1148,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :MarkRecaptureAnalysis a skos:Concept ;
   skos:prefLabel "Mark-Recapture Analysis"@en ;
+  rdfs:label "Mark-Recapture Analysis"@en ;
   skos:definition "Capture-recapture estimators (Petersen, Jolly-Seber, open/Bayesian models) applied to field marks/recoveries."@en ;
   skos:inScheme :EstimateMethodScheme ;
   skos:broader :EstimateMethod ;
@@ -1089,6 +1158,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :TrapModelAnalysis a skos:Concept ;
   skos:prefLabel "Trap Model Analysis"@en ;
+  rdfs:label "Trap Model Analysis"@en ;
   skos:definition "Trap-based counts adjusted with efficiency/coverage models to estimate total passage."@en ;
   skos:inScheme :EstimateMethodScheme ;
   skos:broader :EstimateMethod ;
@@ -1098,6 +1168,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :ReddExpansionAnalysis a skos:Concept ;
   skos:prefLabel "Redd Expansion Analysis"@en ;
+  rdfs:label "Redd Expansion Analysis"@en ;
   skos:definition "Converts redd counts to spawner estimates using spawners-per-redd expansion factors."@en ;
   skos:inScheme :EstimateMethodScheme ;
   skos:broader :EstimateMethod ;
@@ -1107,6 +1178,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 :EstimateMethod a skos:Concept ;
   skos:prefLabel "Estimate Method"@en ;
+  rdfs:label "Estimate Method"@en ;
   skos:definition "A method used to analyze and estimate salmon abundance from enumeration data"@en ;
   skos:inScheme :EstimateMethodScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:MonitoringFieldWorkTheme ;
@@ -1114,6 +1186,7 @@ smn:EnumerationMethod a skos:Concept ;
 
 gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
   skos:prefLabel "WSP rapid-status assessment method"@en ;
+  rdfs:label "WSP rapid-status assessment method"@en ;
   skos:altLabel "WSP rapid status method"@en ;
   skos:definition "The analytical method used to produce rapid-status metrics under the Wild Salmon Policy rapid-status approach."@en ;
   skos:inScheme :EstimateMethodScheme ;
@@ -1129,6 +1202,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :Type1 a skos:Concept ;
   skos:prefLabel "Type-1, True Abundance, high resolution"@en ;
+  rdfs:label "Type-1, True Abundance, high resolution"@en ;
   skos:definition "Total, seasonal counts through fence or fishway; virtually no bypass. Simple, often single step analysis. Reliable resolution of between year differences >10% (in absolute units)."@en ;
   skos:inScheme :EstimateTypeScheme ;
   skos:broader :EstimateType ;
@@ -1137,6 +1211,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :Type2 a skos:Concept ;
   skos:prefLabel "Type-2, True Abundance, medium resolution"@en ;
+  rdfs:label "Type-2, True Abundance, medium resolution"@en ;
   skos:definition "Indirect estimate of total spawner abundance with qualified accuracy and known precision (i.e., a variance estimate—an explicit quantitative measure of uncertainty around the estimate). Derived from high-effort, standardized methods (e.g., mark-recapture, serial counts for area under the curve) with documented analytical conversions (including interpolation/calibration as needed). Reported in absolute units (estimate ± variance). Reliable resolution of between-year differences >25% (in absolute units)."@en ;
   skos:inScheme :EstimateTypeScheme ;
   skos:broader :EstimateType ;
@@ -1145,6 +1220,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :Type3 a skos:Concept ;
   skos:prefLabel "Type-3, Relative Abundance, high resolution"@en ;
+  rdfs:label "Type-3, Relative Abundance, high resolution"@en ;
   skos:definition "Relative abundance index (i.e., not an absolute count) derived from moderate to high effort surveys (typically 3 or more site visits) using standardized methods applied consistently between and within years (e.g., equal-effort surveys executed by walk, swim, overflight). Accuracy and precision are not fully quantified (i.e., no explicit variance estimate), but are assumed stable enough for within-series comparisons. Reliable resolution of between-year differences >25% (in relative units)."@en ;
   skos:inScheme :EstimateTypeScheme ;
   skos:broader :EstimateType ;
@@ -1153,6 +1229,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :Type4 a skos:Concept ;
   skos:prefLabel "Type-4, Relative Abundance, medium resolution"@en ;
+  rdfs:label "Type-4, Relative Abundance, medium resolution"@en ;
   skos:definition "Low to moderate effort (1-4 trips), known survey method. Simple analysis by known methods. Reliable resolution of between year differences >200% (in relative units)."@en ;
   skos:inScheme :EstimateTypeScheme ;
   skos:broader :EstimateType ;
@@ -1161,6 +1238,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :Type5 a skos:Concept ;
   skos:prefLabel "Type-5, Relative Abundance, low resolution"@en ;
+  rdfs:label "Type-5, Relative Abundance, low resolution"@en ;
   skos:definition "Low effort (e.g. 1 trip), use of vaguely defined, inconsistent or poorly executed methods. Unknown to ill defined; inconsistent or poorly executed. Uncertain numeric comparisons, but high reliability for presence or absence."@en ;
   skos:inScheme :EstimateTypeScheme ;
   skos:broader :EstimateType ;
@@ -1169,6 +1247,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :Type6 a skos:Concept ;
   skos:prefLabel "Type-6, Presence or Absence"@en ;
+  rdfs:label "Type-6, Presence or Absence"@en ;
   skos:altLabel "Presence/Not Detected"@en ;
   skos:definition "Non-numeric, year-specific record of presence/not detected (i.e., present/absent without estimating a count), tied to an explicit time and location, with reliable species identification. Underlying field methods may be highly variable; analysis is not required."@en ;
   skos:inScheme :EstimateTypeScheme ;
@@ -1178,6 +1257,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :EstimateType a skos:Concept ;
   skos:prefLabel "Estimate Type"@en ;
+  rdfs:label "Estimate Type"@en ;
   skos:definition "Classification of escapement estimate quality based on Hyatt 1997 framework"@en ;
   skos:inScheme :EstimateTypeScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:DataModelProvenanceTheme ;
@@ -1189,6 +1269,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :DowngradeCriteria a skos:Concept ;
   skos:prefLabel "Downgrade Criteria"@en ;
+  rdfs:label "Downgrade Criteria"@en ;
   skos:definition "Criteria that may result in downgrading an escapement estimate type classification"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:DataModelProvenanceTheme ;
@@ -1196,6 +1277,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :BreachBypass a skos:Concept ;
   skos:prefLabel "Bypass/Breach Risk"@en ;
+  rdfs:label "Bypass/Breach Risk"@en ;
   skos:definition "Bypass or breach risks not monitored and verified negligible"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1205,6 +1287,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :RunCoverage a skos:Concept ;
   skos:prefLabel "Run Coverage"@en ;
+  rdfs:label "Run Coverage"@en ;
   skos:definition "Run-window coverage < 95% of season days"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1214,6 +1297,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :Uptime a skos:Concept ;
   skos:prefLabel "Uptime"@en ;
+  rdfs:label "Uptime"@en ;
   skos:definition "Counting/device uptime < 95% (or <90% with interpolation)"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1223,6 +1307,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :InfillMethod a skos:Concept ;
   skos:prefLabel "Infill Method"@en ;
+  rdfs:label "Infill Method"@en ;
   skos:definition "Interpolation used for missing data; defensibility must be documented"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1232,6 +1317,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :Documentation a skos:Concept ;
   skos:prefLabel "Documentation"@en ;
+  rdfs:label "Documentation"@en ;
   skos:definition "Missing SIL/SEN logs or QA/methods report"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1241,6 +1327,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :CrossSectionCoverage a skos:Concept ;
   skos:prefLabel "Cross-section Coverage"@en ;
+  rdfs:label "Cross-section Coverage"@en ;
   skos:definition "Incomplete cross-section coverage"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1250,6 +1337,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :ReviewQA a skos:Concept ;
   skos:prefLabel "Review/QA"@en ;
+  rdfs:label "Review/QA"@en ;
   skos:definition "Insufficient QA review of automated events"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1259,6 +1347,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :DeviceConfiguration a skos:Concept ;
   skos:prefLabel "Device Configuration"@en ;
+  rdfs:label "Device Configuration"@en ;
   skos:definition "Device not within operational specifications"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1268,6 +1357,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :EnvironmentalConditions a skos:Concept ;
   skos:prefLabel "Environmental Conditions"@en ;
+  rdfs:label "Environmental Conditions"@en ;
   skos:definition "Environmental conditions outside specifications"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1277,6 +1367,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :Visibility a skos:Concept ;
   skos:prefLabel "Visibility"@en ;
+  rdfs:label "Visibility"@en ;
   skos:definition "Poor visibility conditions"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1286,6 +1377,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :Classification a skos:Concept ;
   skos:prefLabel "Classification"@en ;
+  rdfs:label "Classification"@en ;
   skos:definition "Classification/attribution not documented"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1295,6 +1387,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :ReachCoverage a skos:Concept ;
   skos:prefLabel "Reach Coverage"@en ;
+  rdfs:label "Reach Coverage"@en ;
   skos:definition "Insufficient reach coverage"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1304,6 +1397,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :Timing a skos:Concept ;
   skos:prefLabel "Timing"@en ;
+  rdfs:label "Timing"@en ;
   skos:definition "Poor timing of surveys"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1313,6 +1407,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :NumberOfVisits a skos:Concept ;
   skos:prefLabel "Number of Visits"@en ;
+  rdfs:label "Number of Visits"@en ;
   skos:definition "Insufficient number of survey visits"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1322,6 +1417,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :TrapEfficiency a skos:Concept ;
   skos:prefLabel "Trap Efficiency"@en ;
+  rdfs:label "Trap Efficiency"@en ;
   skos:definition "Trap efficiency not measured/validated"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1331,6 +1427,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :EffortStandardization a skos:Concept ;
   skos:prefLabel "Effort Standardization"@en ;
+  rdfs:label "Effort Standardization"@en ;
   skos:definition "Effort not standardized"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1340,6 +1437,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :MarkRecaptureAssumptions a skos:Concept ;
   skos:prefLabel "Mark-Recapture Assumptions"@en ;
+  rdfs:label "Mark-Recapture Assumptions"@en ;
   skos:definition "MR assumptions not evaluated"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1349,6 +1447,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :Detectability a skos:Concept ;
   skos:prefLabel "Detectability"@en ;
+  rdfs:label "Detectability"@en ;
   skos:definition "Detectability factors not validated"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1358,6 +1457,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :PrecisionAccuracy a skos:Concept ;
   skos:prefLabel "Precision/Accuracy"@en ;
+  rdfs:label "Precision/Accuracy"@en ;
   skos:definition "Precision/accuracy weaker than expected for type"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1367,6 +1467,7 @@ gcdfo:WSPRapidStatusAssessmentMethod a skos:Concept ;
 
 :MethodUnknown a skos:Concept ;
   skos:prefLabel "Method Unknown/Inconsistent"@en ;
+  rdfs:label "Method Unknown/Inconsistent"@en ;
   skos:definition "Survey/analytical methods not adequately identified/consistent"@en ;
   skos:inScheme :DowngradeCriteriaScheme ;
   skos:broader :DowngradeCriteria ;
@@ -1619,6 +1720,7 @@ gcdfo:usedProcedure a owl:AnnotationProperty ;
 
 gcdfo:YearBasis a skos:Concept ;
   skos:prefLabel "Year basis"@en ;
+  rdfs:label "Year basis"@en ;
   skos:definition "A year-based temporal reference used to contextualize measurements or rates (e.g., brood year, catch year, or return year)."@en ;
   iao:0000115 "A year-based temporal reference used to contextualize measurements or rates (e.g., brood year, catch year, or return year)."@en ; # definition
   skos:inScheme :YearBasisScheme ;
@@ -1627,6 +1729,7 @@ gcdfo:YearBasis a skos:Concept ;
 
 gcdfo:BroodYear a skos:Concept ;
   skos:prefLabel "Brood year"@en ;
+  rdfs:label "Brood year"@en ;
   skos:definition "The parental year for a group of returning salmon, i.e. the calendar year when the majority of parents of these fish spawned."@en ;
   iao:0000115 "The parental year for a group of returning salmon, i.e. the calendar year when the majority of parents of these fish spawned."@en ; # definition
   skos:inScheme :YearBasisScheme ;
@@ -1639,6 +1742,7 @@ gcdfo:BroodYear a skos:Concept ;
 
 gcdfo:CatchYear a skos:Concept ;
   skos:prefLabel "Catch year"@en ;
+  rdfs:label "Catch year"@en ;
   skos:definition "The calendar year in which returning salmon are caught in fisheries (as opposed to the brood year in which the cohort was spawned)."@en ;
   iao:0000115 "The calendar year in which returning salmon are caught in fisheries (as opposed to the brood year in which the cohort was spawned)."@en ; # definition
   skos:inScheme :YearBasisScheme ;
@@ -1786,6 +1890,7 @@ gcdfo:UpperStockReferencePoint a owl:Class ;
 
 gcdfo:WSPBiologicalStatusZone a skos:Concept ;
   skos:prefLabel "Wild Salmon Policy biological status zone"@en ;
+  rdfs:label "Wild Salmon Policy biological status zone"@en ;
   skos:definition "The biological status of a Conservation Unit (CU) will normally be based on the abundance and distribution of spawners in the unit, or proxies thereof. For each CU, higher and lower benchmarks will be defined that will delimit three status zones: Green, Amber, and Red. As spawner abundance decreases, a CU moves towards the lower status zone, and the extent of management intervention for conservation purposes will increase."@en ;
   skos:inScheme gcdfo:WSPBiologicalStatusZoneScheme ;
   iao:0000119 "Fisheries and Oceans Canada. Wild Salmon Policy 2018-2022 Implementation Plan. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/40728109.pdf."@en ; # definition source
@@ -1795,6 +1900,7 @@ gcdfo:WSPBiologicalStatusZone a skos:Concept ;
 
 gcdfo:GreenZone a gcdfo:WSPBiologicalStatusZone , gcdfo:IntegratedStatusOutcome , skos:Concept ;
   skos:prefLabel "Green zone"@en ;
+  rdfs:label "Green zone"@en ;
   skos:notation "G"^^xsd:string ;
   skos:definition "Social and economic considerations will tend to be the primary drivers for the management of Conservation Units in the Green zone, though ecosystem or other non-consumptive use values could also be considered."@en ;
   skos:inScheme gcdfo:WSPBiologicalStatusZoneScheme, :IntegratedStatusOutcomeScheme ;
@@ -1805,6 +1911,7 @@ gcdfo:GreenZone a gcdfo:WSPBiologicalStatusZone , gcdfo:IntegratedStatusOutcome 
 
 gcdfo:AmberZone a gcdfo:WSPBiologicalStatusZone , gcdfo:IntegratedStatusOutcome , skos:Concept ;
   skos:prefLabel "Amber zone"@en ;
+  rdfs:label "Amber zone"@en ;
   skos:notation "A"^^xsd:string ;
   skos:definition "Amber status implies caution in the management of the Conservation Unit. While a CU in the Amber zone should be at a low risk of loss, there will be a degree of lost production. Decisions about the conservation of CUs in the Amber zone will involve broader consideration of biological, social, and economic issues. "@en ;
   skos:inScheme gcdfo:WSPBiologicalStatusZoneScheme, :IntegratedStatusOutcomeScheme ;
@@ -1815,6 +1922,7 @@ gcdfo:AmberZone a gcdfo:WSPBiologicalStatusZone , gcdfo:IntegratedStatusOutcome 
 
 gcdfo:RedZone a gcdfo:WSPBiologicalStatusZone , gcdfo:IntegratedStatusOutcome , skos:Concept ;
   skos:prefLabel "Red zone"@en ;
+  rdfs:label "Red zone"@en ;
   skos:notation "R"^^xsd:string ;
   skos:definition "A Conservation Unit in the Red zone is undesirable because of the risk of extirpation, and the loss of ecological benefits and salmon production. Changes in status will trigger management actions that will vary depending on species, geographic regions, and cause of the decline."@en ;
   skos:inScheme gcdfo:WSPBiologicalStatusZoneScheme, :IntegratedStatusOutcomeScheme ;
@@ -1871,14 +1979,16 @@ gcdfo:WSPRapidStatusAlgorithmThreshold a owl:Class ;
 
 gcdfo:ConfidenceCategory a skos:Concept ;
   skos:prefLabel "Confidence category"@en ;
+  rdfs:label "Confidence category"@en ;
   skos:definition "Categorical confidence rating (High, Medium, Low) for stock assessment metrics."@en ; # definition
   skos:inScheme :RapidStatusConfidenceScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:WildSalmonPolicyTheme ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
 
   gcdfo:RapidStatusConfidenceHigh a gcdfo:ConfidenceCategory , skos:Concept ;
-  rdfs:label "High rapid-status confidence"@en ;
   skos:prefLabel "High confidence"@en ;
+    rdfs:label "High confidence"@en ;
+    skos:altLabel "High rapid-status confidence"@en ;
   iao:0000115 "Rapid status confidence category indicating that high-quality abundance metrics support the result."@en ; # definition
   skos:definition "Rapid status confidence category indicating that high-quality abundance metrics support the result."@en ;
   skos:inScheme :RapidStatusConfidenceScheme ;
@@ -1886,8 +1996,9 @@ gcdfo:ConfidenceCategory a skos:Concept ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
 
 gcdfo:RapidStatusConfidenceMedium a gcdfo:ConfidenceCategory , skos:Concept ;
-  rdfs:label "Medium rapid-status confidence"@en ;
   skos:prefLabel "Medium confidence"@en ;
+  rdfs:label "Medium confidence"@en ;
+  skos:altLabel "Medium rapid-status confidence"@en ;
   iao:0000115 "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information."@en ; # definition
   skos:definition "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information."@en ;
   skos:inScheme :RapidStatusConfidenceScheme ;
@@ -1895,8 +2006,9 @@ gcdfo:RapidStatusConfidenceMedium a gcdfo:ConfidenceCategory , skos:Concept ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
 
 gcdfo:RapidStatusConfidenceLow a gcdfo:ConfidenceCategory , skos:Concept ;
-  rdfs:label "Low rapid-status confidence"@en ;
   skos:prefLabel "Low confidence"@en ;
+  rdfs:label "Low confidence"@en ;
+  skos:altLabel "Low rapid-status confidence"@en ;
   iao:0000115 "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone)."@en ; # definition
   skos:definition "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone)."@en ;
   skos:inScheme :RapidStatusConfidenceScheme ;
@@ -1955,6 +2067,7 @@ smn:IndicatorRiver a owl:Class ;
 ### AbundanceDataType (SKOS)
 gcdfo:AbundanceDataType a skos:Concept ;
   skos:prefLabel "Abundance data type"@en ;
+  rdfs:label "Abundance data type"@en ;
   skos:definition "A categorical attribute indicating whether an abundance time series is recorded as absolute abundance or as a relative index (used by rapid-status workflows)."@en ;
   iao:0000115 "A categorical attribute indicating whether an abundance time series is recorded as absolute abundance or as a relative index (used by rapid-status workflows)."@en ;
   skos:scopeNote "In SPSR rapid-status workflows, this field distinguishes absolute abundance vs relative index inputs (often abbreviated in code as 'Abs_Abd' and 'RelIdx')."@en ;
@@ -1969,6 +2082,7 @@ gcdfo:AbundanceDataType a skos:Concept ;
 
 gcdfo:RapidStatusMetric a skos:Concept ;
   skos:prefLabel "Rapid status metric"@en ;
+  rdfs:label "Rapid status metric"@en ;
   skos:definition "A compound variable concept representing a metric used by WSP rapid-status workflows."@en ;
   skos:inScheme :RapidStatusMetricScheme ;
   gcdfo:iadoptEntity gcdfo:ConservationUnit ;
@@ -1978,6 +2092,7 @@ gcdfo:RapidStatusMetric a skos:Concept ;
 
 gcdfo:GenerationalAverageAbundance a skos:Concept ;
   skos:prefLabel "Generational average abundance"@en ;
+  rdfs:label "Generational average abundance"@en ;
   skos:definition "The generational average of spawner abundance, calculated as a geometric mean across the number of years corresponding to the most common age at return (generation length), optionally after smoothing depending on CU group."@en ;
   iao:0000115 "The generational average of spawner abundance, calculated as a geometric mean across the number of years corresponding to the most common age at return (generation length), optionally after smoothing depending on CU group."@en ;
   skos:inScheme :RapidStatusMetricScheme ;
@@ -1993,6 +2108,7 @@ gcdfo:GenerationalAverageAbundance a skos:Concept ;
 
 gcdfo:LongTermTrendMetric a skos:Concept ;
   skos:prefLabel "Long-term trend metric"@en ;
+  rdfs:label "Long-term trend metric"@en ;
   skos:definition "A long-term trend metric comparing the current generational average (geometric mean) spawner abundance to the long-term average (geometric mean) spawner abundance for an assessed time series."@en ;
   iao:0000115 "A long-term trend metric comparing the current generational average (geometric mean) spawner abundance to the long-term average (geometric mean) spawner abundance for an assessed time series."@en ;
   skos:inScheme :RapidStatusMetricScheme ;
@@ -2008,6 +2124,7 @@ gcdfo:LongTermTrendMetric a skos:Concept ;
 
 gcdfo:PercentChangeMetric a skos:Concept ;
   skos:prefLabel "Percent change metric"@en ;
+  rdfs:label "Percent change metric"@en ;
   skos:altLabel "Rapid-status percent change metric"@en ;
   skos:definition "A short-term trend metric quantifying the percent (linear) change in spawner abundance over the most recent three generations."@en ;
   iao:0000115 "A short-term trend metric quantifying the percent (linear) change in spawner abundance over the most recent three generations."@en ;
@@ -2024,6 +2141,7 @@ gcdfo:PercentChangeMetric a skos:Concept ;
 
 gcdfo:BenchmarkRatioMetric a skos:Concept ;
   skos:prefLabel "Benchmark ratio metric"@en ;
+  rdfs:label "Benchmark ratio metric"@en ;
   skos:definition "A benchmark-ratio metric equal to the ratio of current generational average spawner abundance to a specified benchmark (lower or upper benchmark), where 1.0 indicates equality to that benchmark."@en ;
   iao:0000115 "A benchmark-ratio metric equal to the ratio of current generational average spawner abundance to a specified benchmark (lower or upper benchmark), where 1.0 indicates equality to that benchmark."@en ;
   skos:inScheme :RapidStatusMetricScheme ;
@@ -2039,6 +2157,7 @@ gcdfo:BenchmarkRatioMetric a skos:Concept ;
 
 gcdfo:ProbabilityDeclineBelowLowerBenchmarkMetric a skos:Concept ;
   skos:prefLabel "Probability of decline below lower benchmark metric"@en ;
+  rdfs:label "Probability of decline below lower benchmark metric"@en ;
   skos:definition "A probability metric estimating the risk that spawner abundance will be below the lower benchmark, given uncertainty in benchmark estimates and/or abundance estimates, for a defined forecast or assessment horizon."@en ;
   iao:0000115 "A probability metric estimating the risk that spawner abundance will be below the lower benchmark, given uncertainty in benchmark estimates and/or abundance estimates, for a defined forecast or assessment horizon."@en ;
   skos:inScheme :RapidStatusMetricScheme ;
@@ -2054,6 +2173,7 @@ gcdfo:ProbabilityDeclineBelowLowerBenchmarkMetric a skos:Concept ;
 
 gcdfo:AbundancePercentileMetric a skos:Concept ;
   skos:prefLabel "Abundance percentile metric"@en ;
+  rdfs:label "Abundance percentile metric"@en ;
   skos:definition "An abundance percentile metric giving the percentile rank of the current generational average spawner abundance relative to a historical reference distribution."@en ;
   iao:0000115 "An abundance percentile metric giving the percentile rank of the current generational average spawner abundance relative to a historical reference distribution."@en ;
   skos:inScheme :RapidStatusMetricScheme ;
@@ -2069,6 +2189,7 @@ gcdfo:AbundancePercentileMetric a skos:Concept ;
 
 gcdfo:RapidStatusScoreMetric a skos:Concept ;
   skos:prefLabel "Rapid status score metric"@en ;
+  rdfs:label "Rapid status score metric"@en ;
   skos:definition "A numeric score produced by a rapid-status algorithm used to represent an ordered status outcome and/or decision-rule position."@en ;
   iao:0000115 "A numeric score produced by a rapid-status algorithm used to represent an ordered status outcome and/or decision-rule position."@en ;
   skos:inScheme :RapidStatusMetricScheme ;
@@ -2100,6 +2221,7 @@ gcdfo:RapidStatusScoreMetric a skos:Concept ;
 
 gcdfo:IntegratedStatusOutcome a skos:Concept ;
   skos:prefLabel "Integrated status outcome"@en ;
+  rdfs:label "Integrated status outcome"@en ;
   skos:definition "Outcome category assigned by integrated WSP status workflows for a Conservation Unit."@en ;
   skos:inScheme :IntegratedStatusOutcomeScheme ;
   gcdfo:theme gcdfo:WildSalmonPolicyTheme, gcdfo:StockAssessmentTheme ;
@@ -2107,6 +2229,7 @@ gcdfo:IntegratedStatusOutcome a skos:Concept ;
 
 gcdfo:IntegratedStatusRedAmber a gcdfo:IntegratedStatusOutcome , skos:Concept ;
   skos:prefLabel "Red/Amber integrated status"@en ;
+  rdfs:label "Red/Amber integrated status"@en ;
   skos:notation "RA"^^xsd:string ;
   skos:definition "Blended integrated status outcome between Red and Amber used when expert evidence supports an intermediate boundary outcome."@en ;
   skos:inScheme :IntegratedStatusOutcomeScheme ;
@@ -2118,6 +2241,7 @@ gcdfo:IntegratedStatusRedAmber a gcdfo:IntegratedStatusOutcome , skos:Concept ;
 
 gcdfo:IntegratedStatusAmberGreen a gcdfo:IntegratedStatusOutcome , skos:Concept ;
   skos:prefLabel "Amber/Green integrated status"@en ;
+  rdfs:label "Amber/Green integrated status"@en ;
   skos:notation "AG"^^xsd:string ;
   skos:definition "Blended integrated status outcome between Amber and Green used when expert evidence supports an intermediate boundary outcome."@en ;
   skos:inScheme :IntegratedStatusOutcomeScheme ;
@@ -2129,6 +2253,7 @@ gcdfo:IntegratedStatusAmberGreen a gcdfo:IntegratedStatusOutcome , skos:Concept 
 
 gcdfo:IntegratedStatusDataDeficient a gcdfo:IntegratedStatusOutcome , skos:Concept ;
   skos:prefLabel "Data deficient integrated status"@en ;
+  rdfs:label "Data deficient integrated status"@en ;
   skos:notation "DD"^^xsd:string ;
   skos:definition "Integrated status outcome indicating insufficient information to assign a biological zone outcome."@en ;
   skos:inScheme :IntegratedStatusOutcomeScheme ;
@@ -2139,6 +2264,7 @@ gcdfo:IntegratedStatusDataDeficient a gcdfo:IntegratedStatusOutcome , skos:Conce
 
 gcdfo:IntegratedStatusUndetermined a gcdfo:IntegratedStatusOutcome , skos:Concept ;
   skos:prefLabel "Undetermined integrated status"@en ;
+  rdfs:label "Undetermined integrated status"@en ;
   skos:altLabel "to be determined"@en ;
   skos:notation "UD"^^xsd:string ;
   skos:definition "Integrated status outcome used when an assessment is unresolved or pending completion."@en ;
@@ -2150,6 +2276,7 @@ gcdfo:IntegratedStatusUndetermined a gcdfo:IntegratedStatusOutcome , skos:Concep
 
 gcdfo:IntegratedStatusNotRed a gcdfo:IntegratedStatusOutcome , skos:Concept ;
   skos:prefLabel "Not-red integrated status"@en ;
+  rdfs:label "Not-red integrated status"@en ;
   skos:notation "NotRed"^^xsd:string ;
   skos:definition "Binary integrated-status outcome indicating the Conservation Unit is not in Red status after binary collapse of integrated outcomes."@en ;
   skos:inScheme :IntegratedStatusOutcomeScheme ;
@@ -2159,6 +2286,7 @@ gcdfo:IntegratedStatusNotRed a gcdfo:IntegratedStatusOutcome , skos:Concept ;
 
 gcdfo:WSPOutputVariable a skos:Concept ;
   skos:prefLabel "WSP output variable"@en ;
+  rdfs:label "WSP output variable"@en ;
   skos:definition "A canonical variable field used in approved Wild Salmon Policy output tables."@en ;
   skos:inScheme :WSPOutputVariableScheme ;
   gcdfo:theme gcdfo:WildSalmonPolicyTheme, gcdfo:StockAssessmentTheme, gcdfo:DataModelProvenanceTheme ;
@@ -2166,6 +2294,7 @@ gcdfo:WSPOutputVariable a skos:Concept ;
 
 gcdfo:Species a skos:Concept ;
   skos:prefLabel "Species"@en ;
+  rdfs:label "Species"@en ;
   skos:definition "Species identity field used in canonical WSP outputs."@en ;
   skos:scopeNote "Use taxonomic IRIs (for example DwC/GBIF/ITIS) where available; canonical approved outputs currently use common-name strings such as Chinook, Sockeye, Coho, Chum, and Pink."@en ;
   skos:inScheme :WSPOutputVariableScheme ;
@@ -2177,6 +2306,7 @@ gcdfo:Species a skos:Concept ;
 
 gcdfo:ConservationUnitName a skos:Concept ;
   skos:prefLabel "Conservation Unit name"@en ;
+  rdfs:label "Conservation Unit name"@en ;
   skos:altLabel "Stock (canonical WSP output column label)"@en ;
   skos:definition "Full Conservation Unit name field used in canonical WSP outputs."@en ;
   skos:scopeNote "The canonical WSP output column is labelled Stock but currently carries CU names. Entity-level stock semantics are represented with smn:Stock."@en ;
@@ -2189,6 +2319,7 @@ gcdfo:ConservationUnitName a skos:Concept ;
 
 gcdfo:IntegratedStatusRaw a skos:Concept ;
   skos:prefLabel "Integrated status (raw)"@en ;
+  rdfs:label "Integrated status (raw)"@en ;
   skos:altLabel "IntStatusRaw"@en ;
   skos:definition "Expert-assigned integrated WSP status outcome prior to collapsed-category derivations."@en ;
   skos:scopeNote "Observed canonical values include Red, Amber, Green, RedAmber, AmberGreen, DD, and UD."@en ;
@@ -2203,6 +2334,7 @@ gcdfo:IntegratedStatusRaw a skos:Concept ;
 
 gcdfo:IntegratedStatusRawCode a skos:Concept ;
   skos:prefLabel "Raw integrated status code"@en ;
+  rdfs:label "Raw integrated status code"@en ;
   skos:altLabel "IntStatusRaw_Short"@en ;
   skos:definition "Short code representation of IntegratedStatusRaw values."@en ;
   skos:scopeNote "Observed canonical codes include R, RA, A, AG, G, DD, and UD."@en ;
@@ -2216,6 +2348,7 @@ gcdfo:IntegratedStatusRawCode a skos:Concept ;
 
 gcdfo:IntegratedStatusCollapsedCode a skos:Concept ;
   skos:prefLabel "Collapsed integrated status code"@en ;
+  rdfs:label "Collapsed integrated status code"@en ;
   skos:altLabel "IntStatus_Short"@en ;
   skos:definition "Short code representation of the three-category collapsed integrated status field."@en ;
   skos:scopeNote "Observed canonical codes include R, A, G, DD, and UD."@en ;
@@ -2229,6 +2362,7 @@ gcdfo:IntegratedStatusCollapsedCode a skos:Concept ;
 
 gcdfo:IntegratedStatusFiveCategoryAlias a skos:Concept ;
   skos:prefLabel "Integrated status (5-category legacy alias)"@en ;
+  rdfs:label "Integrated status (5-category legacy alias)"@en ;
   skos:altLabel "IntStatus5"@en ;
   skos:definition "Legacy alias field that duplicates IntStatusRaw in canonical WSP outputs."@en ;
   skos:scopeNote "Canonical variable descriptions mark this field as to be removed."@en ;
@@ -2242,6 +2376,7 @@ gcdfo:IntegratedStatusFiveCategoryAlias a skos:Concept ;
 
 gcdfo:IntegratedStatusThreeCategory a skos:Concept ;
   skos:prefLabel "Integrated status (3-category collapsed)"@en ;
+  rdfs:label "Integrated status (3-category collapsed)"@en ;
   skos:altLabel "IntStatus3"@en ;
   skos:definition "Derived integrated-status field where RedAmber collapses to Red, AmberGreen collapses to Amber, and DD/UD are preserved."@en ;
   skos:inScheme :WSPOutputVariableScheme ;
@@ -2256,6 +2391,7 @@ gcdfo:IntegratedStatusThreeCategory a skos:Concept ;
 
 gcdfo:IntegratedStatusBinary a skos:Concept ;
   skos:prefLabel "Integrated status (binary red/not-red)"@en ;
+  rdfs:label "Integrated status (binary red/not-red)"@en ;
   skos:altLabel "IntStatus2"@en ;
   skos:definition "Derived integrated-status field collapsed to Red, NotRed, DD, or UD categories."@en ;
   skos:inScheme :WSPOutputVariableScheme ;
@@ -2270,6 +2406,7 @@ gcdfo:IntegratedStatusBinary a skos:Concept ;
 
 gcdfo:LongTermTrendMetricStatus a skos:Concept ;
   skos:prefLabel "Long-term trend metric status"@en ;
+  rdfs:label "Long-term trend metric status"@en ;
   skos:altLabel "LongTrendCat"@en ;
   skos:definition "Categorical status derived from the long-term trend metric using WSP status-zone thresholds."@en ;
   skos:scopeNote "Operational thresholds are typically 0.50 (lower) and 0.75 (upper) of long-term average abundance."@en ;
@@ -2284,6 +2421,7 @@ gcdfo:LongTermTrendMetricStatus a skos:Concept ;
 
 gcdfo:PercentChangeMetricStatus a skos:Concept ;
   skos:prefLabel "Percent change metric status"@en ;
+  rdfs:label "Percent change metric status"@en ;
   skos:altLabel "PercChangeCat"@en ;
   skos:definition "Categorical status derived from the percent-change metric using WSP status-zone thresholds."@en ;
   skos:scopeNote "Operational thresholds in current rapid-status implementations commonly use -25% and -15% boundaries."@en ;
@@ -2298,6 +2436,7 @@ gcdfo:PercentChangeMetricStatus a skos:Concept ;
 
 gcdfo:ProbabilityDeclineBelowLowerBenchmarkMetricStatus a skos:Concept ;
   skos:prefLabel "Probability-of-decline-below-lower-benchmark metric status"@en ;
+  rdfs:label "Probability-of-decline-below-lower-benchmark metric status"@en ;
   skos:altLabel "ProbDeclBelowLBMCat"@en ;
   skos:definition "Categorical status derived from the probability-of-decline-below-lower-benchmark metric."@en ;
   skos:scopeNote "Canonical approved output currently records this field as NA and variable metadata labels it as not currently in use."@en ;
@@ -2312,6 +2451,7 @@ gcdfo:ProbabilityDeclineBelowLowerBenchmarkMetricStatus a skos:Concept ;
 
 gcdfo:AbundancePercentileMetricStatus a skos:Concept ;
   skos:prefLabel "Abundance percentile metric status"@en ;
+  rdfs:label "Abundance percentile metric status"@en ;
   skos:altLabel "PercentileCat"@en ;
   skos:definition "Categorical status derived from abundance percentile metric values."@en ;
   skos:scopeNote "Canonical approved outputs contain non-NA values despite stale variable-description text indicating NA."@en ;
@@ -2326,6 +2466,7 @@ gcdfo:AbundancePercentileMetricStatus a skos:Concept ;
 
 gcdfo:RelativeAbundanceMetricStatus a skos:Concept ;
   skos:prefLabel "Relative abundance metric status"@en ;
+  rdfs:label "Relative abundance metric status"@en ;
   skos:altLabel "RelAbdCat"@en ;
   skos:definition "Categorical status derived from the relative abundance metric benchmark ratio."@en ;
   skos:inScheme :WSPOutputVariableScheme ;
@@ -2339,6 +2480,7 @@ gcdfo:RelativeAbundanceMetricStatus a skos:Concept ;
 
 gcdfo:AbsoluteAbundanceMetricStatus a skos:Concept ;
   skos:prefLabel "Absolute abundance metric status"@en ;
+  rdfs:label "Absolute abundance metric status"@en ;
   skos:altLabel "AbsAbdCat"@en ;
   skos:definition "Categorical status derived from the absolute abundance metric benchmark ratio."@en ;
   skos:scopeNote "Absolute abundance status uses 1,000 and 10,000 spawner thresholds under current WSP guidance."@en ;
@@ -2355,6 +2497,7 @@ gcdfo:AbsoluteAbundanceMetricStatus a skos:Concept ;
 
 gcdfo:ReturnYear a skos:Concept ;
   skos:prefLabel "Return year"@en ;
+  rdfs:label "Return year"@en ;
   skos:definition "The calendar year in which adult salmon return from the ocean to freshwater systems (a year basis used to contextualize run/return-related measurements)."@en ;
   iao:0000115 "The calendar year in which adult salmon return from the ocean to freshwater systems (a year basis used to contextualize run/return-related measurements)."@en ;
   skos:inScheme :YearBasisScheme ;
@@ -2366,6 +2509,7 @@ gcdfo:ReturnYear a skos:Concept ;
 
 gcdfo:UnrankedIndexQuality a skos:Concept ;
     skos:prefLabel "Unranked index quality"@en ;
+  rdfs:label "Unranked index quality"@en ;
     skos:definition "A data quality category indicating that no spawner-abundance estimate classification / index quality rating was assigned for the record (i.e., an 'Unknown' estimate classification with no quality rating)."@en ;
     iao:0000115 "A data quality category indicating that no spawner-abundance estimate classification / index quality rating was assigned for the record (i.e., an 'Unknown' estimate classification with no quality rating)."@en ;
     skos:inScheme :EstimateTypeScheme ;
@@ -2377,6 +2521,7 @@ gcdfo:UnrankedIndexQuality a skos:Concept ;
 
 gcdfo:ExpansionFactor a skos:Concept ;
   skos:prefLabel "Expansion factor"@en ;
+  rdfs:label "Expansion factor"@en ;
   skos:definition "A multiplicative factor used to expand observed counts or detections from a sampled subset (e.g., indicator sites, PIT detections) to an estimated total abundance or escapement."@en ;
   iao:0000115 "A multiplicative factor used to expand observed counts or detections from a sampled subset (e.g., indicator sites, PIT detections) to an estimated total abundance or escapement."@en ;
   skos:inScheme :EstimateMethodScheme ;

--- a/ontology/dfo-salmon.ttl
+++ b/ontology/dfo-salmon.ttl
@@ -466,7 +466,7 @@ smn:SalmonOriginScheme a skos:ConceptScheme ;
   skos:definition "Controlled vocabulary for describing the origin of individual salmon (e.g., natural-origin, hatchery-origin, mixed-origin)."@en ;
   skos:hasTopConcept smn:SalmonOrigin ;
   gcdfo:theme gcdfo:SalmonEnhancementHatcheriesTheme, gcdfo:StockAssessmentTheme, gcdfo:GeneticsStockCompositionTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 :StockStatusZoneScheme a skos:ConceptScheme ;
   skos:prefLabel "Stock Status Zone Scheme (legacy alias)"@en ;
@@ -556,14 +556,14 @@ smn:MeasurementContextScheme a skos:ConceptScheme ;
   skos:definition "Controlled vocabulary for compositional measurement context qualifiers (for example, catch context, run context)."@en ;
   skos:hasTopConcept smn:MeasurementContext ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:DataModelProvenanceTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:LifePhaseScheme a skos:ConceptScheme ;
   skos:prefLabel "Life phase scheme"@en ;
   skos:definition "Controlled vocabulary for life-phase or fishery/migration segment qualifiers used to stratify measurements (e.g., ocean, terminal, mainstem)."@en ;
   skos:hasTopConcept smn:LifePhase ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 :BenchmarkLevelScheme a skos:ConceptScheme ;
   skos:prefLabel "Benchmark Level Scheme"@en ;
@@ -744,7 +744,7 @@ smn:MeasurementContext a skos:Concept ;
   skos:definition "A context qualifier used to disambiguate the interpretation of a measurement column."@en ;
   skos:inScheme smn:MeasurementContextScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:DataModelProvenanceTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:CatchContext a skos:Concept ;
   skos:prefLabel "Catch context"@en ;
@@ -752,7 +752,7 @@ smn:CatchContext a skos:Concept ;
   skos:inScheme smn:MeasurementContextScheme ;
   skos:broader smn:MeasurementContext ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:RunContext a skos:Concept ;
   skos:prefLabel "Run context"@en ;
@@ -760,7 +760,7 @@ smn:RunContext a skos:Concept ;
   skos:inScheme smn:MeasurementContextScheme ;
   skos:broader smn:MeasurementContext ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:SpawnerStageContext a skos:Concept ;
   skos:prefLabel "Spawner stage context"@en ;
@@ -768,7 +768,7 @@ smn:SpawnerStageContext a skos:Concept ;
   skos:inScheme smn:MeasurementContextScheme ;
   skos:broader smn:MeasurementContext ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 gcdfo:RecruitStageContext a skos:Concept ;
   skos:prefLabel "Recruit stage context"@en ;
@@ -784,7 +784,7 @@ smn:SurvivalOrMortalityContext a skos:Concept ;
   skos:inScheme smn:MeasurementContextScheme ;
   skos:broader smn:MeasurementContext ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 gcdfo:ManagementReferenceContext a skos:Concept ;
   skos:prefLabel "Management reference context"@en ;
@@ -807,7 +807,7 @@ smn:SalmonOrigin a skos:Concept ;
   skos:definition "Origin category describing whether salmon are naturally produced, hatchery produced, or mixed-origin."@en ;
   skos:inScheme smn:SalmonOriginScheme ;
   gcdfo:theme gcdfo:SalmonEnhancementHatcheriesTheme, gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:HatcheryOrigin a skos:Concept ;
   skos:prefLabel "Hatchery-origin"@en ;
@@ -817,7 +817,7 @@ smn:HatcheryOrigin a skos:Concept ;
   iao:0000119 "Fisheries and Oceans Canada. 2018. Review of genetically based targets for enhanced contributions to Canadian Pacific Chinook Salmon populations. DFO Canadian Science Advisory Secretariat Science Advisory Report 2018/001 (Erratum: October 2023)."@en ; # definition source
   dcterms:source <https://www.dfo-mpo.gc.ca/csas-sccs/Publications/SAR-AS/2018/2018_001-eng.html> ;
   gcdfo:theme gcdfo:SalmonEnhancementHatcheriesTheme, gcdfo:StockAssessmentTheme, gcdfo:GeneticsStockCompositionTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:NaturalOrigin a skos:Concept ;
   skos:prefLabel "Natural-origin"@en ;
@@ -827,14 +827,14 @@ smn:NaturalOrigin a skos:Concept ;
   iao:0000119 "Fisheries and Oceans Canada. 2018. Review of genetically based targets for enhanced contributions to Canadian Pacific Chinook Salmon populations. DFO Canadian Science Advisory Secretariat Science Advisory Report 2018/001 (Erratum: October 2023)."@en ; # definition source
   dcterms:source <https://www.dfo-mpo.gc.ca/csas-sccs/Publications/SAR-AS/2018/2018_001-eng.html> ;
   gcdfo:theme gcdfo:WildSalmonPolicyTheme, gcdfo:StockAssessmentTheme, gcdfo:GeneticsStockCompositionTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:LifePhase a skos:Concept ;
   skos:prefLabel "Life phase"@en ;
   skos:definition "A phase or segment used to stratify salmon measurements by where or when they apply (e.g., ocean phase, terminal phase)."@en ;
   skos:inScheme smn:LifePhaseScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:OceanPhase a skos:Concept ;
   skos:prefLabel "Ocean phase"@en ;
@@ -843,7 +843,7 @@ smn:OceanPhase a skos:Concept ;
   skos:inScheme smn:LifePhaseScheme ;
   skos:broader smn:LifePhase ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:TerminalPhase a skos:Concept ;
   skos:prefLabel "Terminal phase"@en ;
@@ -851,7 +851,7 @@ smn:TerminalPhase a skos:Concept ;
   skos:inScheme smn:LifePhaseScheme ;
   skos:broader smn:LifePhase ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:MainstemPhase a skos:Concept ;
   skos:prefLabel "Mainstem phase"@en ;
@@ -859,7 +859,7 @@ smn:MainstemPhase a skos:Concept ;
   skos:inScheme smn:LifePhaseScheme ;
   skos:broader smn:LifePhase ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:InRiverPhase a skos:Concept ;
   skos:prefLabel "In-river phase"@en ;
@@ -868,7 +868,7 @@ smn:InRiverPhase a skos:Concept ;
   skos:inScheme smn:LifePhaseScheme ;
   skos:broader smn:LifePhase ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 gcdfo:LowerBenchmark a skos:Concept ;
   skos:prefLabel "Lower benchmark"@en ;
@@ -928,7 +928,7 @@ smn:EnumerationMethod a skos:Concept ;
   skos:scopeNote "DFO profile note: this ontology uses the shared `smn:EnumerationMethod` concept directly and constrains local narrower methods beneath it."@en ;
   skos:inScheme :EnumerationMethodScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:MonitoringFieldWorkTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 :FixedSiteCensusManual a skos:Concept ;
   skos:prefLabel "Fixed Site Census (Manual)"@en ;
@@ -1383,21 +1383,21 @@ smn:ObservedRateOrAbundance a owl:Class ;
   iao:0000115 "A measurement datum representing an empirically observed rate, count, or abundance derived from monitoring or survey data."@en ; # definition
   rdfs:subClassOf iao:0000109 ; # measurement datum
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:DataModelProvenanceTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:TargetOrLimitRateOrAbundance a owl:Class ;
   rdfs:label "Target or limit rate or abundance"@en ;
   iao:0000115 "A value specification representing a policy- or model-defined target or limit, such as TAC or UMSY."@en ; # definition
   rdfs:subClassOf iao:0000109 ; # measurement datum
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:PolicyGovernanceTheme, gcdfo:DataModelProvenanceTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:ReportingOrManagementStratum a owl:Class ;
   rdfs:label "Reporting or management stratum"@en ;
   iao:0000115 "An information-defined grouping of fish populations used for reporting, conservation assessment, or management purposes. Examples include Conservation Units (CUs), Stock Management Units (MUs), and Designatable Units (DUs)."@en ; # definition
   rdfs:subClassOf iao:0000030 ; # information content entity
   gcdfo:theme gcdfo:PolicyGovernanceTheme, gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 #################################################################
 # Object Properties — Biological and Management Unit Composition
@@ -1408,7 +1408,7 @@ smn:hasDeme a owl:ObjectProperty ;
   iao:0000115 "Relates a population to one of its constituent demes."@en ; # definition
   rdfs:domain smn:Population ;
   rdfs:range smn:Deme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> ;
   gcdfo:theme gcdfo:WildSalmonPolicyTheme, gcdfo:GeneticsStockCompositionTheme .
 
 smn:demeOf a owl:ObjectProperty ;
@@ -1417,7 +1417,7 @@ smn:demeOf a owl:ObjectProperty ;
   owl:inverseOf smn:hasDeme ;
   rdfs:domain smn:Deme ;
   rdfs:range smn:Population ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> ;
   gcdfo:theme gcdfo:WildSalmonPolicyTheme, gcdfo:GeneticsStockCompositionTheme .
 
 smn:hasPopulation a owl:ObjectProperty ;
@@ -1426,7 +1426,7 @@ smn:hasPopulation a owl:ObjectProperty ;
   rdfs:comment "DFO profile note: within this ontology, `smn:hasPopulation` is primarily used for ConservationUnit-to-Population composition."@en ;
   rdfs:domain gcdfo:ConservationUnit ;
   rdfs:range smn:Population ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> ;
   gcdfo:theme gcdfo:WildSalmonPolicyTheme, gcdfo:StockAssessmentTheme .
 
 smn:populationOf a owl:ObjectProperty ;
@@ -1436,7 +1436,7 @@ smn:populationOf a owl:ObjectProperty ;
   owl:inverseOf smn:hasPopulation ;
   rdfs:domain smn:Population ;
   rdfs:range gcdfo:ConservationUnit ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> ;
   gcdfo:theme gcdfo:WildSalmonPolicyTheme, gcdfo:StockAssessmentTheme .
 
 gcdfo:hasConservationUnit a owl:ObjectProperty ;
@@ -1652,7 +1652,7 @@ smn:Stock a owl:Class ;
   iao:0000119 "Fisheries and Oceans Canada. Introduction to Stock Assessment - Glossary. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html."@en ; # definition source
   dcterms:source <https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html> ;
   rdfs:subClassOf smn:ReportingOrManagementStratum ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> ;
   skos:altLabel "Fish stock"@en ;
   gcdfo:theme gcdfo:PolicyGovernanceTheme, gcdfo:StockAssessmentTheme, gcdfo:FisheriesManagementTheme .
 
@@ -1660,7 +1660,7 @@ smn:Deme a owl:Class ;
   rdfs:label "Deme"@en ;
   iao:0000115 "A local interbreeding group of organisms within a species. In salmon, a deme typically corresponds to a spawning population at a specific site. Demes are the finest biological unit and make up populations."@en ; # definition
   rdfs:subClassOf dwc:Organism ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> ;
   gcdfo:theme gcdfo:WildSalmonPolicyTheme, gcdfo:GeneticsStockCompositionTheme, gcdfo:StockAssessmentTheme .
 
 smn:Population a owl:Class ;
@@ -1668,7 +1668,7 @@ smn:Population a owl:Class ;
   iao:0000115 "A group of organisms of the same species occupying a defined area that interbreed and share a gene pool. In salmon, populations are composed of one or more demes and form the biological basis for Conservation Units."@en ; # definition
   rdfs:comment "DFO profile note: this ontology applies `smn:Population` in Wild Salmon Policy / Conservation Unit contexts."@en ;
   rdfs:subClassOf dwc:Organism ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> ;
   gcdfo:theme gcdfo:WildSalmonPolicyTheme, gcdfo:GeneticsStockCompositionTheme, gcdfo:StockAssessmentTheme .
 
 smn:StockAssessment a owl:Class ;
@@ -1678,7 +1678,7 @@ smn:StockAssessment a owl:Class ;
   iao:0000119 "Fisheries and Oceans Canada. Introduction to Stock Assessment. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/module-1/09-eng.html."@en ; # definition source
   dcterms:source <https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/module-1/09-eng.html> ;
   gcdfo:theme gcdfo:StockAssessmentTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 gcdfo:ConservationUnit a owl:Class ;
   rdfs:label "Conservation Unit"@en ;
@@ -1719,7 +1719,7 @@ smn:Escapement a owl:Class ;
   iao:0000119 "Fisheries and Oceans Canada. 2005. Canada's Policy for Conservation of Wild Pacific Salmon. https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/315577.pdf."@en ; # definition source
   dcterms:source <https://waves-vagues.dfo-mpo.gc.ca/library-bibliotheque/315577.pdf> ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:MonitoringFieldWorkTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:SurveyEvent a owl:Class ;
   rdfs:label "Survey event"@en ;
@@ -1728,7 +1728,7 @@ smn:SurveyEvent a owl:Class ;
   iao:0000119 "Fisheries and Oceans Canada. About the Sustainability Survey for Fisheries. https://www.dfo-mpo.gc.ca/reports-rapports/regs/sff-cpd/survey-sondage/about-propos-en.html."@en ; # definition source
   dcterms:source <https://www.dfo-mpo.gc.ca/reports-rapports/regs/sff-cpd/survey-sondage/about-propos-en.html> ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:MonitoringFieldWorkTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:EscapementSurveyEvent a owl:Class ;
   rdfs:label "Escapement Survey Event"@en ;
@@ -1736,14 +1736,14 @@ smn:EscapementSurveyEvent a owl:Class ;
   iao:0000115 "A survey event specifically for estimating escapement."@en ; # definition
   rdfs:subClassOf smn:SurveyEvent ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:MonitoringFieldWorkTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:EscapementMeasurement a owl:Class ;
   rdfs:label "Escapement measurement"@en ;
   iao:0000115 "A measurement or estimate of escapement tied to a stock and a survey event."@en ; # definition
   rdfs:subClassOf iao:0000109, sosa:Result ; # measurement datum / observation result
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:MonitoringFieldWorkTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:ReferencePoint a owl:Class ;
   rdfs:label "Reference point"@en ;
@@ -1751,7 +1751,7 @@ smn:ReferencePoint a owl:Class ;
   rdfs:comment "DFO profile note: this ontology applies `smn:ReferencePoint` in DFO fisheries-management and assessment workflows."@en ;
   iao:0000119 "Fisheries and Oceans Canada. Introduction to Stock Assessment - Glossary. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html."@en ; # definition source
   dcterms:source <https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html> ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:FisheriesManagementTheme, gcdfo:PolicyGovernanceTheme ;
   rdfs:subClassOf iao:0000030 . # Information content entity.
 
@@ -1763,7 +1763,7 @@ smn:LimitReferencePoint a owl:Class ;
   iao:0000119 "Fisheries and Oceans Canada. Introduction to Stock Assessment - Glossary. https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html."@en ; # definition source
   dcterms:source <https://www.dfo-mpo.gc.ca/science/species-especes/fisheries-halieutiques/assessment-evaluation/glossary-glossaire/index-eng.html> ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:FisheriesManagementTheme, gcdfo:PolicyGovernanceTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:FisheriesReferencePointLower a owl:Class ;
   rdfs:label "Fisheries Reference Point - Lower"@en ;
@@ -1772,7 +1772,7 @@ smn:FisheriesReferencePointLower a owl:Class ;
   rdfs:subClassOf smn:LimitReferencePoint ;
   iao:0000119 "Fisheries and Oceans Canada. (2022). Methodologies and Guidelines for Defining Limit Reference Points for Pacific Salmon. DFO Can. Sci. Advis. Sec. Sci. Advis. Rep. 2022/030. (Erratum: December 2022)."@en ; # definition source
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:FisheriesManagementTheme, gcdfo:PolicyGovernanceTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 gcdfo:UpperStockReferencePoint a owl:Class ;
   rdfs:label "Upper stock reference"@en ;
@@ -1840,7 +1840,7 @@ smn:MetricBenchmark a owl:Class ;
   dcterms:source <https://publications.gc.ca/site/eng/9.928944/publication.html> ;
   rdfs:subClassOf iao:0000030 ; # Information content entity
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:WildSalmonPolicyTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 gcdfo:LowerBiologicalBenchmark a owl:Class ;
   rdfs:label "Lower biological benchmark"@en ;
@@ -1910,7 +1910,7 @@ smn:ExploitationRate a owl:Class ;
   iao:0000119 "Fisheries and Oceans Canada. Pacific Salmon - Glossary (Pacific Region). https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html."@en ; # definition source
   dcterms:source <https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html> ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:FisheriesManagementTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 gcdfo:ObservedExploitationRate a owl:Class ;
   rdfs:label "Observed exploitation rate"@en ;
@@ -1935,7 +1935,7 @@ smn:TotalExploitationRate a owl:Class ;
   rdfs:subClassOf gcdfo:ObservedExploitationRate ;
   iao:0000115 "The overall proportion of the total return of adult salmon removed by all fisheries over a defined period, aggregating across gear or fishery components."@en ; # definition
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:FisheriesManagementTheme ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:IndicatorRiver a owl:Class ;
   rdfs:label "Indicator river"@en ;
@@ -1944,7 +1944,7 @@ smn:IndicatorRiver a owl:Class ;
   iao:0000115 "A reporting and assessment stratum identifying monitored indicator streams that provide representative indices of spawner abundance for nearby streams."@en ; # definition
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:MonitoringFieldWorkTheme, gcdfo:PolicyGovernanceTheme ;
   dcterms:source <https://www.salmonexplorer.ca/methods/glossary.html> ;
-  rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
+  rdfs:isDefinedBy <https://w3id.org/smn> .
 
 
 #################################################################

--- a/ontology/dfo-salmon.ttl
+++ b/ontology/dfo-salmon.ttl
@@ -59,6 +59,7 @@ skos:closeMatch    a owl:AnnotationProperty .
 
 gcdfo:theme a owl:AnnotationProperty ;
   rdfs:label "theme"@en ;
+  iao:0000115 "Associates OWL classes and SKOS concepts with high-level thematic concept schemes (e.g., Stock Assessment, GSI, Policy)."@en ;
   rdfs:comment "Associates OWL classes and SKOS concepts with high-level thematic concept schemes (e.g., Stock Assessment, GSI, Policy)."@en ;
   gcdfo:theme gcdfo:DataModelProvenanceTheme ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
@@ -1879,6 +1880,7 @@ gcdfo:ConfidenceCategory a skos:Concept ;
   rdfs:label "High rapid-status confidence"@en ;
   skos:prefLabel "High confidence"@en ;
   iao:0000115 "Rapid status confidence category indicating that high-quality abundance metrics support the result."@en ; # definition
+  skos:definition "Rapid status confidence category indicating that high-quality abundance metrics support the result."@en ;
   skos:inScheme :RapidStatusConfidenceScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:WildSalmonPolicyTheme ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
@@ -1887,6 +1889,7 @@ gcdfo:RapidStatusConfidenceMedium a gcdfo:ConfidenceCategory , skos:Concept ;
   rdfs:label "Medium rapid-status confidence"@en ;
   skos:prefLabel "Medium confidence"@en ;
   iao:0000115 "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information."@en ; # definition
+  skos:definition "Rapid status confidence category indicating mixed evidence or reliance on trend metrics supplemented by some abundance information."@en ;
   skos:inScheme :RapidStatusConfidenceScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:WildSalmonPolicyTheme ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .
@@ -1895,6 +1898,7 @@ gcdfo:RapidStatusConfidenceLow a gcdfo:ConfidenceCategory , skos:Concept ;
   rdfs:label "Low rapid-status confidence"@en ;
   skos:prefLabel "Low confidence"@en ;
   iao:0000115 "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone)."@en ; # definition
+  skos:definition "Rapid status confidence category indicating limited supporting data (for example, derived from trend metrics alone)."@en ;
   skos:inScheme :RapidStatusConfidenceScheme ;
   gcdfo:theme gcdfo:StockAssessmentTheme, gcdfo:WildSalmonPolicyTheme ;
   rdfs:isDefinedBy <https://w3id.org/gcdfo/salmon> .


### PR DESCRIPTION
## Summary
- fix README guidance so it matches the canonical conventions checklist
- add missing annotation completeness for `gcdfo:theme`
- mirror rapid-status confidence definitions into `skos:definition` for better SKOS/docs rendering
- refresh generated docs/artifacts

## Notes
- no new definitions or sources were invented; this only reuses wording already present in the ontology
- required annotation gaps identified in the compliance pass are closed

## Validation
- `make ci`
