### PR TITLE
docs: route durable salmon knowledge to salmon-knowledge-commons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,40 @@ Progressive disclosure rule: enumerate skills by reading YAML frontmatter only (
 - Update `docs/tech-debt.md` when technical debt is introduced (what, why, impact, and the intended fix path).
 - Create `docs/adr/<####-descriptive-adr>.md` (from `docs/adr/0001.md`) when making an architectural decision (i.e., you choose between competing approaches).
 
+## Durable Salmon Knowledge (write it down, elsewhere)
+
+Salmon knowledge commons: a separate repository holding source-backed prose
+about salmon, where every claim carries a citation.
+
+- When work here establishes something durable about **salmon** — biology,
+  ecology, management, what a term actually means, why a modelling choice went
+  the way it did — write it to
+  [`salmon-knowledge-commons`](https://github.com/salmon-data-mobilization/salmon-knowledge-commons).
+- Do NOT leave it in a PR description, a commit message, or a chat transcript.
+  Those evaporate, and the next agent re-derives it — which for an ontology
+  means a second term minted for a distinction someone already settled.
+- If you can push there, open a PR. If you cannot, put the finding in your
+  **Evidence** output with its sources, so a maintainer can.
+- Source-backed claims only. A claim with no citation is rejected there.
+- Never assert your own verification. `generated` records who wrote a card;
+  `verified` records who independently checked it. If you wrote it, you did not
+  verify it.
+
+Ontology gap: a concept that has no matching term in any of the vocabularies —
+`smn`, `gcdfo`, or the PSC controlled vocabulary.
+
+- Gaps are recorded in the commons too, each with a note saying what a term
+  would have to say and where it should be minted (`mint_target`).
+- That register is the front end of the ecosystem's term-request pipeline. A
+  gap left in a transcript is a term request that never gets filed.
+- Gaps whose `mint_target` is `gcdfo` are DFO-specific policy and
+  administration, and land here. **Species and other all-agency biological
+  concepts go to `smn`, never `gcdfo`** — the same boundary rule already stated
+  in the Project Overview below.
+- Reading the register is a reasonable way to decide what to mint next. Minting
+  remains a term-by-term decision under review; a gap entry is a proposal, not
+  an instruction.
+
 ## Tooling Defaults
 
 - Calling Context7 MCP is REQUIRED for language specs, syntax, and official docs anytime a language is used that could benefit from up to date references


### PR DESCRIPTION
Adds one section to `AGENTS.md`, between Verification and Docs and Tooling Defaults. No ontology change, no build change.

**Do not merge yet** — one of six matching PRs across the hub nodes, for review together.

## Active Path Declaration

- Canonical file changed: `AGENTS.md` (one new `##` section, 33 lines).
- Wiring: none. This is agent guidance, not code.
- Verify: `git show --stat` shows a single file; `git log -1 --format=%B | grep -i co-authored` returns nothing.

## Evidence

```
$ git show --stat --oneline HEAD
 AGENTS.md | 33 +++++++++++++++++++++++++++++++++
 1 file changed, 33 insertions(+)

$ git log -1 --format=%B | grep -i "co-authored"
(no output)
```

The repo rule against `Co-authored-by` lines and hidden authorship markers is respected — the commit carries no trailer.

## Why

Findings about **salmon itself** — what a term actually means, why a class is modelled the way it is, how two vocabularies relate — have had nowhere to go in this ecosystem, so they have been landing in PR descriptions and chat transcripts. Those evaporate. For an ontology repo the cost is concrete: the next agent re-derives the distinction and mints a second term for something already settled, and nothing in the repo shows that it happened before.

## What the section says

Write it to [`salmon-knowledge-commons`](https://github.com/salmon-data-mobilization/salmon-knowledge-commons) — a separate repository of source-backed prose about salmon where every claim carries a citation. Open a PR there if you can push; otherwise put the finding in the **Evidence** output with its sources. Source-backed claims only, and never assert your own verification.

It also explains the gap register in terms of this repo's own boundary rule:

- A gap is a concept with no matching term in `smn`, `gcdfo` or the PSC CV, recorded with a note saying what a term would have to say and where it should be minted.
- Gaps with `mint_target: gcdfo` are DFO-specific policy and administration, and land here.
- **Species and other all-agency biological concepts go to `smn`, never `gcdfo`** — restating the boundary already in the Project Overview, so the register cannot be read as a licence to pull biology into the DFO namespace.
- A gap entry is a **proposal, not an instruction to mint**. Minting stays a term-by-term decision under review, matching the `red` autonomy entry in the Agent Context block.

Per the repo's term-of-art rule, "salmon knowledge commons" and "ontology gap" are each defined in one plain sentence where first used.

## Not done

No Kanban board item was created for this. Flagging it since the Git Workflow section requires one.

## Context

[salmon-knowledge-commons#1](https://github.com/salmon-data-mobilization/salmon-knowledge-commons/pull/1) is a live example: seven concepts, 24 gaps, 4 of which target `gcdfo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)